### PR TITLE
Added minor fixes for bugs and warnings

### DIFF
--- a/example/glow.ipynb
+++ b/example/glow.ipynb
@@ -2,16 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Glow"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# Import required packages\n",
     "import torch\n",
@@ -21,15 +19,13 @@
     "\n",
     "from matplotlib import pyplot as plt\n",
     "from tqdm import tqdm"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
    "source": [
     "# Set up model\n",
     "\n",
@@ -74,22 +70,23 @@
     "# Move model on GPU if available\n",
     "enable_cuda = True\n",
     "device = torch.device('cuda' if torch.cuda.is_available() and enable_cuda else 'cpu')\n",
-    "model = model.to(device)\n",
-    "model = model.double()"
-   ]
+    "model = model.to(device)"
+   ],
+   "outputs": [],
+   "metadata": {
+    "scrolled": false
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# Prepare training data\n",
     "batch_size = 128\n",
     "\n",
     "logit = nf.utils.Logit(alpha=0.05)\n",
     "transform = tv.transforms.Compose([tv.transforms.ToTensor(), nf.utils.Jitter(),\n",
-    "                                   logit, nf.utils.ToDevice(device)])\n",
+    "                                   logit])\n",
     "train_data = tv.datasets.CIFAR10('/scratch2/vs488/flow/lars/datasets/', train=True,\n",
     "                                 download=True, transform=transform)\n",
     "train_loader = torch.utils.data.DataLoader(train_data, batch_size=batch_size, shuffle=True,\n",
@@ -100,15 +97,13 @@
     "test_loader = torch.utils.data.DataLoader(test_data, batch_size=batch_size)\n",
     "\n",
     "train_iter = iter(train_loader)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
    "source": [
     "# Train model\n",
     "max_iter = 2000\n",
@@ -123,6 +118,7 @@
     "    except StopIteration:\n",
     "        train_iter = iter(train_loader)\n",
     "        x, y = next(train_iter)\n",
+    "    x, y = x.to(device), y.to(device)\n",
     "    optimizer.zero_grad()\n",
     "    loss = model.forward_kld(x, y.to(device))\n",
     "        \n",
@@ -137,15 +133,15 @@
     "plt.plot(loss_hist, label='loss')\n",
     "plt.legend()\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "scrolled": false
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
    "source": [
     "# Model samples\n",
     "num_sample = 10\n",
@@ -160,16 +156,20 @@
     "\n",
     "    del(x, y, x_)\n",
     "    torch.cuda.empty_cache()\n"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "scrolled": false
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "nf.utils.bitsPerDimDataset(model, test_loader)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/normflow/flows.py
+++ b/normflow/flows.py
@@ -613,7 +613,7 @@ class Invertible1x1Conv(Flow):
         super().__init__()
         self.num_channels = num_channels
         self.use_lu = use_lu
-        Q = torch.qr(torch.randn(self.num_channels, self.num_channels))[0]
+        Q = torch.linalg.qr(torch.randn(self.num_channels, self.num_channels))[0]
         if use_lu:
             P, L, U = torch.lu_unpack(*Q.lu())
             self.register_buffer('P', P) # remains fixed during optimization
@@ -687,7 +687,7 @@ class InvertibleAffine(Flow):
         super().__init__()
         self.num_channels = num_channels
         self.use_lu = use_lu
-        Q = torch.qr(torch.randn(self.num_channels, self.num_channels))[0]
+        Q = torch.linalg.qr(torch.randn(self.num_channels, self.num_channels))[0]
         if use_lu:
             P, L, U = torch.lu_unpack(*Q.lu())
             self.register_buffer('P', P) # remains fixed during optimization

--- a/normflow/nets.py
+++ b/normflow/nets.py
@@ -42,13 +42,13 @@ class MLP(nn.Module):
         if output_fn is not None:
             if score_scale is not None:
                 net.append(utils.ConstScaleLayer(score_scale))
-            if output_fn is "sigmoid":
+            if output_fn == "sigmoid":
                 net.append(nn.Sigmoid())
-            elif output_fn is "relu":
+            elif output_fn == "relu":
                 net.append(nn.ReLU())
-            elif output_fn is "tanh":
+            elif output_fn == "tanh":
                 net.append(nn.Tanh())
-            elif output_fn is "clampexp":
+            elif output_fn == "clampexp":
                 net.append(utils.ClampExp())
             else:
                 NotImplementedError("This output function is not implemented.")


### PR DESCRIPTION
This commit made three changes to the original repo:
1. Fixes the warning regarding the 'is' keyword:
```
/home/donglin/Github/normalizing-flows/normflow/nets.py:45: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if output_fn is "sigmoid":
/home/donglin/Github/normalizing-flows/normflow/nets.py:47: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif output_fn is "relu":
/home/donglin/Github/normalizing-flows/normflow/nets.py:49: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif output_fn is "tanh":
/home/donglin/Github/normalizing-flows/normflow/nets.py:51: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif output_fn is "clampexp":
```

2. Fixes the warning regarding 'torch.qr':

```
/home/donglin/Github/normalizing-flows/normflow/flows.py:616: UserWarning: torch.qr is deprecated in favor of torch.linalg.qr and will be removed in a future PyTorch release.
The boolean parameter 'some' has been replaced with a string parameter 'mode'.
Q, R = torch.qr(A, some)
should be replaced with
Q, R = torch.linalg.qr(A, 'reduced' if some else 'complete') (Triggered internally at  /opt/conda/conda-bld/pytorch_1623448278899/work/aten/src/ATen/native/BatchLinearAlgebra.cpp:1940.)
  Q = torch.qr(torch.randn(self.num_channels, self.num_channels))[0]
```

3. Eliminated the "nf.util.ToDevice" call during the data pre-processing in glow.ipynb