### PR TITLE
Wrapped flag attribute as scalar tensor

### DIFF
--- a/normflow/flows/normalization.py
+++ b/normflow/flows/normalization.py
@@ -14,8 +14,8 @@ class ActNorm(AffineConstFlow):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.data_dep_init_done_cpu = torch.tensor(0.)
-        self.register_buffer('data_dep_init_done', self.data_dep_init_done_cpu)
+        # self.data_dep_init_done_cpu = torch.tensor(0.)
+        self.register_buffer('data_dep_init_done', torch.tensor(0.))
 
     def forward(self, z):
         # first batch is used for initialization, c.f. batchnorm
@@ -24,7 +24,7 @@ class ActNorm(AffineConstFlow):
             s_init = -torch.log(z.std(dim=self.batch_dims, keepdim=True) + 1e-6)
             self.s.data = s_init.data
             self.t.data = (-z.mean(dim=self.batch_dims, keepdim=True) * torch.exp(self.s)).data
-            self.data_dep_init_done = torch.tensor(1.)
+            self.data_dep_init_done[...] = 1.
         return super().forward(z)
 
     def inverse(self, z):
@@ -34,7 +34,7 @@ class ActNorm(AffineConstFlow):
             s_init = torch.log(z.std(dim=self.batch_dims, keepdim=True) + 1e-6)
             self.s.data = s_init.data
             self.t.data = z.mean(dim=self.batch_dims, keepdim=True).data
-            self.data_dep_init_done = torch.tensor(1.)
+            self.data_dep_init_done[...] = 1.
         return super().inverse(z)
 
 

--- a/normflow/flows/reshape.py
+++ b/normflow/flows/reshape.py
@@ -101,7 +101,7 @@ class Squeeze(Flow):
         super().__init__()
 
     def forward(self, z):
-        log_det = 0
+        log_det = z.new_tensor(0)
         s = z.size()
         z = z.view(s[0], s[1] // 4, 2, 2, s[2], s[3])
         z = z.permute(0, 1, 4, 2, 5, 3).contiguous()
@@ -109,7 +109,7 @@ class Squeeze(Flow):
         return z, log_det
 
     def inverse(self, z):
-        log_det = 0
+        log_det = z.new_tensor(0)
         s = z.size()
         z = z.view(*s[:2], s[2] // 2, 2, s[3] // 2, 2)
         z = z.permute(0, 1, 3, 5, 2, 4).contiguous()


### PR DESCRIPTION
Hi,
I was trying to integrate your code in pytorch lightning framework and found that some scalar flag attributes caused exceptions when parallelizing the nn.Module. This PR wraps them as tensors for safety and should not change code behavior or performance.