### PR TITLE
Vberenz/mkdocs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,1 @@
-# Welcome to MkDocs
-
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
-
-## Commands
-
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
-
-## Project layout
-
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+../README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,3 @@
+# API references
+
+::: normflows

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,14 +2,16 @@ site_name: Normalizing Flows
 site_url: https://github.com/VincentStimper/normalizing-flows
 
 
-theme:
-  name: "material"
-
 plugins:
   - search
   - autorefs
-  - mkdocstrings
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_submodules: true
   - mkdocs-jupyter 
 
 nav:
+  - about: index.md
   - API: references.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: Normalizing Flows
+site_url: https://github.com/VincentStimper/normalizing-flows
+
+
+theme:
+  name: "material"
+
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings
+  - mkdocs-jupyter 
+
+nav:
+  - API: references.md

--- a/normflows/core.py
+++ b/normflows/core.py
@@ -12,8 +12,8 @@ class NormalizingFlow(nn.Module):
     """
 
     def __init__(self, q0, flows, p=None):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           q0: Base distribution
           flows: List of flows
@@ -25,7 +25,7 @@ class NormalizingFlow(nn.Module):
         self.p = p
 
     def forward_kld(self, x):
-        """ Estimates forward KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
+        """Estimates forward KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
 
         Args:
           x: Batch sampled from target distribution
@@ -42,8 +42,8 @@ class NormalizingFlow(nn.Module):
         return -torch.mean(log_q)
 
     def reverse_kld(self, num_samples=1, beta=1.0, score_fn=True):
-        """ Estimates reverse KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
-        
+        """Estimates reverse KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
+
         Args:
           num_samples: Number of samples to draw from base distribution
           beta: Annealing parameter, see [arXiv 1505.05770](https://arxiv.org/abs/1505.05770)
@@ -71,8 +71,8 @@ class NormalizingFlow(nn.Module):
         return torch.mean(log_q) - beta * torch.mean(log_p)
 
     def reverse_alpha_div(self, num_samples=1, alpha=1, dreg=False):
-        """ Alpha divergence when sampling from q
-        
+        """Alpha divergence when sampling from q
+
         Args:
           num_samples: Number of samples to draw
           dreg: Flag whether to use Double Reparametrized Gradient estimator, see [arXiv 1810.04152](https://arxiv.org/abs/1810.04152)
@@ -105,7 +105,7 @@ class NormalizingFlow(nn.Module):
         return loss
 
     def sample(self, num_samples=1):
-        """ Samples from flow-based approximate distribution
+        """Samples from flow-based approximate distribution
 
         Args:
           num_samples: Number of samples to draw
@@ -120,8 +120,8 @@ class NormalizingFlow(nn.Module):
         return z, log_q
 
     def log_prob(self, x):
-        """ Get log probability for batch
-        
+        """Get log probability for batch
+
         Args:
           x: Batch
 
@@ -137,16 +137,16 @@ class NormalizingFlow(nn.Module):
         return log_q
 
     def save(self, path):
-        """ Save state dict of model
-        
+        """Save state dict of model
+
         Args:
           path: Path including filename where to save model
         """
         torch.save(self.state_dict(), path)
 
     def load(self, path):
-        """ Load model from state dict
-        
+        """Load model from state dict
+
         Args:
           path: Path including filename where to load model from
         """
@@ -159,7 +159,7 @@ class ClassCondFlow(nn.Module):
     """
 
     def __init__(self, q0, flows):
-        """ Constructor
+        """Constructor
 
         Args:
           q0: Base distribution
@@ -170,8 +170,8 @@ class ClassCondFlow(nn.Module):
         self.flows = nn.ModuleList(flows)
 
     def forward_kld(self, x, y):
-        """ Estimates forward KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
-        
+        """Estimates forward KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
+
         Args:
           x: Batch sampled from target distribution
 
@@ -187,7 +187,7 @@ class ClassCondFlow(nn.Module):
         return -torch.mean(log_q)
 
     def sample(self, num_samples=1, y=None):
-        """ Samples from flow-based approximate distribution
+        """Samples from flow-based approximate distribution
 
         Args:
           num_samples: Number of samples to draw
@@ -203,8 +203,8 @@ class ClassCondFlow(nn.Module):
         return z, log_q
 
     def log_prob(self, x, y):
-        """ Get log probability for batch
-        
+        """Get log probability for batch
+
         Args:
           x: Batch
           y: Classes of x
@@ -221,7 +221,7 @@ class ClassCondFlow(nn.Module):
         return log_q
 
     def save(self, path):
-        """ Save state dict of model
+        """Save state dict of model
 
         Args:
          param path: Path including filename where to save model
@@ -229,7 +229,7 @@ class ClassCondFlow(nn.Module):
         torch.save(self.state_dict(), path)
 
     def load(self, path):
-        """ Load model from state dict
+        """Load model from state dict
 
         Args:
           path: Path including filename where to load model from
@@ -243,10 +243,10 @@ class MultiscaleFlow(nn.Module):
     """
 
     def __init__(self, q0, flows, merges, transform=None, class_cond=True):
-        """ Constructor
+        """Constructor
 
         Args:
-        
+
           q0: List of base distribution
           flows: List of list of flows for each level
           merges: List of merge/split operations (forward pass must do merge)
@@ -263,8 +263,8 @@ class MultiscaleFlow(nn.Module):
         self.class_cond = class_cond
 
     def forward_kld(self, x, y=None):
-        """ Estimates forward KL divergence, see see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
-        
+        """Estimates forward KL divergence, see see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
+
         Args:
           x: Batch sampled from target distribution
 
@@ -274,8 +274,8 @@ class MultiscaleFlow(nn.Module):
         return -torch.mean(self.log_prob(x, y))
 
     def forward(self, x, y=None):
-        """ Get negative log-likelihood for maximum likelihood training
-        
+        """Get negative log-likelihood for maximum likelihood training
+
         Args:
           x: Batch of data
           y: Batch of targets, if applicable
@@ -283,7 +283,7 @@ class MultiscaleFlow(nn.Module):
         return -self.log_prob(x, y)
 
     def sample(self, num_samples=1, y=None, temperature=None):
-        """ Samples from flow-based approximate distribution
+        """Samples from flow-based approximate distribution
 
         Args:
           num_samples: Number of samples to draw
@@ -318,8 +318,8 @@ class MultiscaleFlow(nn.Module):
         return z, log_q
 
     def log_prob(self, x, y):
-        """ Get log probability for batch
-        
+        """Get log probability for batch
+
         Args:
           x: Batch
           y: Classes of x
@@ -348,15 +348,15 @@ class MultiscaleFlow(nn.Module):
         return log_q
 
     def save(self, path):
-        """ Save state dict of model
-        
+        """Save state dict of model
+
         Args:
           path: Path including filename where to save model
         """
         torch.save(self.state_dict(), path)
 
     def load(self, path):
-        """ Load model from state dict
+        """Load model from state dict
 
         Args:
           path: Path including filename where to load model from
@@ -364,8 +364,8 @@ class MultiscaleFlow(nn.Module):
         self.load_state_dict(torch.load(path))
 
     def set_temperature(self, temperature):
-        """ Set temperature for temperature a annealed sampling
-        
+        """Set temperature for temperature a annealed sampling
+
         Args:
           temperature: Temperature parameter
         """
@@ -391,8 +391,8 @@ class NormalizingFlowVAE(nn.Module):
     """
 
     def __init__(self, prior, q0=distributions.Dirac(), flows=None, decoder=None):
-        """ Constructor of normalizing flow model
-        
+        """Constructor of normalizing flow model
+
         Args:
           prior: Prior distribution of te VAE, i.e. Gaussian
           decoder: Optional decoder
@@ -406,8 +406,8 @@ class NormalizingFlowVAE(nn.Module):
         self.q0 = q0
 
     def forward(self, x, num_samples=1):
-        """ Takes data batch, samples num_samples for each data point from base distribution
-        
+        """Takes data batch, samples num_samples for each data point from base distribution
+
         Args:
           x: data batch
           num_samples: number of samples to draw for each data point

--- a/normflows/core.py
+++ b/normflows/core.py
@@ -12,11 +12,12 @@ class NormalizingFlow(nn.Module):
     """
 
     def __init__(self, q0, flows, p=None):
-        """
-        Constructor
-        :param q0: Base distribution
-        :param flows: List of flows
-        :param p: Target distribution
+        """ Constructor
+        
+        Args:
+          q0: Base distribution
+          flows: List of flows
+          p: Target distribution
         """
         super().__init__()
         self.q0 = q0
@@ -24,10 +25,13 @@ class NormalizingFlow(nn.Module):
         self.p = p
 
     def forward_kld(self, x):
-        """
-        Estimates forward KL divergence, see arXiv 1912.02762
-        :param x: Batch sampled from target distribution
-        :return: Estimate of forward KL divergence averaged over batch
+        """ Estimates forward KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
+
+        Args:
+          x: Batch sampled from target distribution
+
+        Returns:
+          Estimate of forward KL divergence averaged over batch
         """
         log_q = torch.zeros(len(x), device=x.device)
         z = x
@@ -38,13 +42,15 @@ class NormalizingFlow(nn.Module):
         return -torch.mean(log_q)
 
     def reverse_kld(self, num_samples=1, beta=1.0, score_fn=True):
-        """
-        Estimates reverse KL divergence, see arXiv 1912.02762
-        :param num_samples: Number of samples to draw from base distribution
-        :param beta: Annealing parameter, see arXiv 1505.05770
-        :param score_fn: Flag whether to include score function in gradient, see
-        arXiv 1703.09194
-        :return: Estimate of the reverse KL divergence averaged over latent samples
+        """ Estimates reverse KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
+        
+        Args:
+          num_samples: Number of samples to draw from base distribution
+          beta: Annealing parameter, see [arXiv 1505.05770](https://arxiv.org/abs/1505.05770)
+          score_fn: Flag whether to include score function in gradient, see [arXiv 1703.09194](https://arxiv.org/abs/1703.09194)
+
+        Returns:
+          Estimate of the reverse KL divergence averaged over latent samples
         """
         z, log_q_ = self.q0(num_samples)
         log_q = torch.zeros_like(log_q_)
@@ -65,12 +71,14 @@ class NormalizingFlow(nn.Module):
         return torch.mean(log_q) - beta * torch.mean(log_p)
 
     def reverse_alpha_div(self, num_samples=1, alpha=1, dreg=False):
-        """
-        Alpha divergence when sampling from q
-        :param num_samples: Number of samples to draw
-        :param dreg: Flag whether to use Double Reparametrized Gradient estimator,
-        see arXiv 1810.04152
-        :return: Alpha divergence
+        """ Alpha divergence when sampling from q
+        
+        Args:
+          num_samples: Number of samples to draw
+          dreg: Flag whether to use Double Reparametrized Gradient estimator, see [arXiv 1810.04152](https://arxiv.org/abs/1810.04152)
+
+        Returns:
+          Alpha divergence
         """
         z, log_q = self.q0(num_samples)
         for flow in self.flows:
@@ -97,10 +105,13 @@ class NormalizingFlow(nn.Module):
         return loss
 
     def sample(self, num_samples=1):
-        """
-        Samples from flow-based approximate distribution
-        :param num_samples: Number of samples to draw
-        :return: Samples, log probability
+        """ Samples from flow-based approximate distribution
+
+        Args:
+          num_samples: Number of samples to draw
+
+        Returns:
+          Samples, log probability
         """
         z, log_q = self.q0(num_samples)
         for flow in self.flows:
@@ -109,10 +120,13 @@ class NormalizingFlow(nn.Module):
         return z, log_q
 
     def log_prob(self, x):
-        """
-        Get log probability for batch
-        :param x: Batch
-        :return: log probability
+        """ Get log probability for batch
+        
+        Args:
+          x: Batch
+
+        Returns:
+          log probability
         """
         log_q = torch.zeros(len(x), dtype=x.dtype, device=x.device)
         z = x
@@ -123,16 +137,18 @@ class NormalizingFlow(nn.Module):
         return log_q
 
     def save(self, path):
-        """
-        Save state dict of model
-        :param path: Path including filename where to save model
+        """ Save state dict of model
+        
+        Args:
+          path: Path including filename where to save model
         """
         torch.save(self.state_dict(), path)
 
     def load(self, path):
-        """
-        Load model from state dict
-        :param path: Path including filename where to load model from
+        """ Load model from state dict
+        
+        Args:
+          path: Path including filename where to load model from
         """
         self.load_state_dict(torch.load(path))
 
@@ -143,20 +159,24 @@ class ClassCondFlow(nn.Module):
     """
 
     def __init__(self, q0, flows):
-        """
-        Constructor
-        :param q0: Base distribution
-        :param flows: List of flows
+        """ Constructor
+
+        Args:
+          q0: Base distribution
+          flows: List of flows
         """
         super().__init__()
         self.q0 = q0
         self.flows = nn.ModuleList(flows)
 
     def forward_kld(self, x, y):
-        """
-        Estimates forward KL divergence, see arXiv 1912.02762
-        :param x: Batch sampled from target distribution
-        :return: Estimate of forward KL divergence averaged over batch
+        """ Estimates forward KL divergence, see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
+        
+        Args:
+          x: Batch sampled from target distribution
+
+        Returns:
+          Estimate of forward KL divergence averaged over batch
         """
         log_q = torch.zeros(len(x), dtype=x.dtype, device=x.device)
         z = x
@@ -167,11 +187,14 @@ class ClassCondFlow(nn.Module):
         return -torch.mean(log_q)
 
     def sample(self, num_samples=1, y=None):
-        """
-        Samples from flow-based approximate distribution
-        :param num_samples: Number of samples to draw
-        :param y: Classes to sample from, will be sampled uniformly if None
-        :return: Samples, log probability
+        """ Samples from flow-based approximate distribution
+
+        Args:
+          num_samples: Number of samples to draw
+          y: Classes to sample from, will be sampled uniformly if None
+
+        Returns:
+          Samples, log probability
         """
         z, log_q = self.q0(num_samples, y)
         for flow in self.flows:
@@ -180,11 +203,14 @@ class ClassCondFlow(nn.Module):
         return z, log_q
 
     def log_prob(self, x, y):
-        """
-        Get log probability for batch
-        :param x: Batch
-        :param y: Classes of x
-        :return: log probability
+        """ Get log probability for batch
+        
+        Args:
+          x: Batch
+          y: Classes of x
+
+        Returns:
+          log probability
         """
         log_q = torch.zeros(len(x), dtype=x.dtype, device=x.device)
         z = x
@@ -195,16 +221,18 @@ class ClassCondFlow(nn.Module):
         return log_q
 
     def save(self, path):
-        """
-        Save state dict of model
-        :param path: Path including filename where to save model
+        """ Save state dict of model
+
+        Args:
+         param path: Path including filename where to save model
         """
         torch.save(self.state_dict(), path)
 
     def load(self, path):
-        """
-        Load model from state dict
-        :param path: Path including filename where to load model from
+        """ Load model from state dict
+
+        Args:
+          path: Path including filename where to load model from
         """
         self.load_state_dict(torch.load(path))
 
@@ -215,13 +243,15 @@ class MultiscaleFlow(nn.Module):
     """
 
     def __init__(self, q0, flows, merges, transform=None, class_cond=True):
-        """
-        Constructor
-        :param q0: List of base distribution
-        :param flows: List of list of flows for each level
-        :param merges: List of merge/split operations (forward pass must do merge)
-        :param transform: Initial transformation of inputs
-        :param class_cond: Flag, indicated whether model has class conditional
+        """ Constructor
+
+        Args:
+        
+          q0: List of base distribution
+          flows: List of list of flows for each level
+          merges: List of merge/split operations (forward pass must do merge)
+          transform: Initial transformation of inputs
+          class_cond: Flag, indicated whether model has class conditional
         base distributions
         """
         super().__init__()
@@ -233,29 +263,35 @@ class MultiscaleFlow(nn.Module):
         self.class_cond = class_cond
 
     def forward_kld(self, x, y=None):
-        """
-        Estimates forward KL divergence, see arXiv 1912.02762
-        :param x: Batch sampled from target distribution
-        :return: Estimate of forward KL divergence averaged over batch
+        """ Estimates forward KL divergence, see see [arXiv 1912.02762](https://arxiv.org/abs/1912.02762)
+        
+        Args:
+          x: Batch sampled from target distribution
+
+        Returns:
+          Estimate of forward KL divergence averaged over batch
         """
         return -torch.mean(self.log_prob(x, y))
 
     def forward(self, x, y=None):
-        """
-        Get negative log-likelihood for maximum likelihood training
-        :param x: Batch of data
-        :param y: Batch of targets, if applicable
-        :return: NLL
+        """ Get negative log-likelihood for maximum likelihood training
+        
+        Args:
+          x: Batch of data
+          y: Batch of targets, if applicable
         """
         return -self.log_prob(x, y)
 
     def sample(self, num_samples=1, y=None, temperature=None):
-        """
-        Samples from flow-based approximate distribution
-        :param num_samples: Number of samples to draw
-        :param y: Classes to sample from, will be sampled uniformly if None
-        :param temperature: Temperature parameter for temp annealed sampling
-        :return: Samples, log probability
+        """ Samples from flow-based approximate distribution
+
+        Args:
+          num_samples: Number of samples to draw
+          y: Classes to sample from, will be sampled uniformly if None
+          temperature: Temperature parameter for temp annealed sampling
+
+        Returns:
+          Samples, log probability
         """
         if temperature is not None:
             self.set_temperature(temperature)
@@ -282,11 +318,14 @@ class MultiscaleFlow(nn.Module):
         return z, log_q
 
     def log_prob(self, x, y):
-        """
-        Get log probability for batch
-        :param x: Batch
-        :param y: Classes of x
-        :return: log probability
+        """ Get log probability for batch
+        
+        Args:
+          x: Batch
+          y: Classes of x
+
+        Returns:
+          log probability
         """
         log_q = 0
         z = x
@@ -309,23 +348,26 @@ class MultiscaleFlow(nn.Module):
         return log_q
 
     def save(self, path):
-        """
-        Save state dict of model
-        :param path: Path including filename where to save model
+        """ Save state dict of model
+        
+        Args:
+          path: Path including filename where to save model
         """
         torch.save(self.state_dict(), path)
 
     def load(self, path):
-        """
-        Load model from state dict
-        :param path: Path including filename where to load model from
+        """ Load model from state dict
+
+        Args:
+          path: Path including filename where to load model from
         """
         self.load_state_dict(torch.load(path))
 
     def set_temperature(self, temperature):
-        """
-        Set temperature for temperature a annealed sampling
-        :param temperature: Temperature parameter
+        """ Set temperature for temperature a annealed sampling
+        
+        Args:
+          temperature: Temperature parameter
         """
         for q0 in self.q0:
             if hasattr(q0, "temperature"):
@@ -349,12 +391,13 @@ class NormalizingFlowVAE(nn.Module):
     """
 
     def __init__(self, prior, q0=distributions.Dirac(), flows=None, decoder=None):
-        """
-        Constructor of normalizing flow model
-        :param prior: Prior distribution of te VAE, i.e. Gaussian
-        :param decoder: Optional decoder
-        :param flows: Flows to transform output of base encoder
-        :param q0: Base Encoder
+        """ Constructor of normalizing flow model
+        
+        Args:
+          prior: Prior distribution of te VAE, i.e. Gaussian
+          decoder: Optional decoder
+          flows: Flows to transform output of base encoder
+          q0: Base Encoder
         """
         super().__init__()
         self.prior = prior
@@ -363,11 +406,14 @@ class NormalizingFlowVAE(nn.Module):
         self.q0 = q0
 
     def forward(self, x, num_samples=1):
-        """
-        Takes data batch, samples num_samples for each data point from base distribution
-        :param x: data batch
-        :param num_samples: number of samples to draw for each data point
-        :return: latent variables for each batch and sample, log_q, and log_p
+        """ Takes data batch, samples num_samples for each data point from base distribution
+        
+        Args:
+          x: data batch
+          num_samples: number of samples to draw for each data point
+
+        Returns:
+          latent variables for each batch and sample, log_q, and log_p
         """
         z, log_q = self.q0(x, num_samples=num_samples)
         # Flatten batch and sample dim

--- a/normflows/distributions/base.py
+++ b/normflows/distributions/base.py
@@ -15,19 +15,19 @@ class BaseDistribution(nn.Module):
         super().__init__()
 
     def forward(self, num_samples=1):
-        """ Samples from base distribution and calculates log probability
-        
+        """Samples from base distribution and calculates log probability
+
         Args:
           num_samples: Number of samples to draw from the distriubtion
-        
+
         Returns:
           Samples drawn from the distribution, log probability
         """
         raise NotImplementedError
 
     def log_prob(self, z):
-        """ Calculate log probability of batch of samples
-        
+        """Calculate log probability of batch of samples
+
         Args:
           z: Batch of random variables to determine log probability for
 
@@ -43,7 +43,7 @@ class DiagGaussian(BaseDistribution):
     """
 
     def __init__(self, shape, trainable=True):
-        """ Constructor
+        """Constructor
 
         Args:
           shape: Tuple with shape of data, if int shape has one dimension
@@ -95,7 +95,7 @@ class UniformGaussian(BaseDistribution):
     """
 
     def __init__(self, ndim, ind, scale=None):
-        """ Constructor
+        """Constructor
 
         Args:
           ndim: Int, number of dimensions
@@ -167,7 +167,7 @@ class ClassCondDiagGaussian(BaseDistribution):
     """
 
     def __init__(self, shape, num_classes):
-        """ Constructor
+        """Constructor
 
         Args:
           shape: Tuple with shape of data, if int shape has one dimension
@@ -240,7 +240,7 @@ class GlowBase(BaseDistribution):
     """
 
     def __init__(self, shape, num_classes=None, logscale_factor=3.0):
-        """ Constructor
+        """Constructor
 
         Args:
           shape: Shape of the variables
@@ -365,8 +365,8 @@ class AffineGaussian(BaseDistribution):
     """
 
     def __init__(self, shape, affine_shape, num_classes=None):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           shape: Shape of the variables
           affine_shape: Shape of the parameters in the affine transformation
@@ -461,7 +461,7 @@ class GaussianMixture(BaseDistribution):
     def __init__(
         self, n_modes, dim, loc=None, scale=None, weights=None, trainable=True
     ):
-        """ Constructor
+        """Constructor
 
         Args:
           n_modes: Number of modes of the mixture model
@@ -549,8 +549,8 @@ class GaussianPCA(BaseDistribution):
     """
 
     def __init__(self, dim, latent_dim=None, sigma=0.1):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           dim: Number of dimensions of the flow variables
           latent_dim: Number of dimensions of the latent "content" variable;

--- a/normflows/distributions/base.py
+++ b/normflows/distributions/base.py
@@ -15,18 +15,24 @@ class BaseDistribution(nn.Module):
         super().__init__()
 
     def forward(self, num_samples=1):
-        """
-        Samples from base distribution and calculates log probability
-        :param num_samples: Number of samples to draw from the distriubtion
-        :return: Samples drawn from the distribution, log probability
+        """ Samples from base distribution and calculates log probability
+        
+        Args:
+          num_samples: Number of samples to draw from the distriubtion
+        
+        Returns:
+          Samples drawn from the distribution, log probability
         """
         raise NotImplementedError
 
     def log_prob(self, z):
-        """
-        Calculate log probability of batch of samples
-        :param z: Batch of random variables to determine log probability for
-        :return: log probability for each batch element
+        """ Calculate log probability of batch of samples
+        
+        Args:
+          z: Batch of random variables to determine log probability for
+
+        Returns:
+          log probability for each batch element
         """
         raise NotImplementedError
 
@@ -37,9 +43,10 @@ class DiagGaussian(BaseDistribution):
     """
 
     def __init__(self, shape, trainable=True):
-        """
-        Constructor
-        :param shape: Tuple with shape of data, if int shape has one dimension
+        """ Constructor
+
+        Args:
+          shape: Tuple with shape of data, if int shape has one dimension
         """
         super().__init__()
         if isinstance(shape, int):
@@ -88,12 +95,12 @@ class UniformGaussian(BaseDistribution):
     """
 
     def __init__(self, ndim, ind, scale=None):
-        """
-        Constructor
-        :param ndim: Int, number of dimensions
-        :param ind: Iterable, indices of uniformly distributed entries
-        :param scale: Iterable, standard deviation of Gaussian or width of
-        uniform distribution
+        """ Constructor
+
+        Args:
+          ndim: Int, number of dimensions
+          ind: Iterable, indices of uniformly distributed entries
+          scale: Iterable, standard deviation of Gaussian or width of uniform distribution
         """
         super().__init__()
         self.ndim = ndim
@@ -160,10 +167,11 @@ class ClassCondDiagGaussian(BaseDistribution):
     """
 
     def __init__(self, shape, num_classes):
-        """
-        Constructor
-        :param shape: Tuple with shape of data, if int shape has one dimension
-        :param num_classes: Number of classes to condition on
+        """ Constructor
+
+        Args:
+          shape: Tuple with shape of data, if int shape has one dimension
+          num_classes: Number of classes to condition on
         """
         super().__init__()
         if isinstance(shape, int):
@@ -232,12 +240,12 @@ class GlowBase(BaseDistribution):
     """
 
     def __init__(self, shape, num_classes=None, logscale_factor=3.0):
-        """
-        Constructor
-        :param shape: Shape of the variables
-        :param num_classes: Number of classes if the base is class conditional,
-        None otherwise
-        :param logscale_factor: Scaling factor for mean and log variance
+        """ Constructor
+
+        Args:
+          shape: Shape of the variables
+          num_classes: Number of classes if the base is class conditional, None otherwise
+          logscale_factor: Scaling factor for mean and log variance
         """
         super().__init__()
         # Save shape and related statistics
@@ -357,12 +365,12 @@ class AffineGaussian(BaseDistribution):
     """
 
     def __init__(self, shape, affine_shape, num_classes=None):
-        """
-        Constructor
-        :param shape: Shape of the variables
-        :param affine_shape: Shape of the parameters in the affine transformation
-        :param num_classes: Number of classes if the base is class conditional,
-        None otherwise
+        """ Constructor
+        
+        Args:
+          shape: Shape of the variables
+          affine_shape: Shape of the parameters in the affine transformation
+          num_classes: Number of classes if the base is class conditional, None otherwise
         """
         super().__init__()
         self.shape = shape
@@ -453,14 +461,15 @@ class GaussianMixture(BaseDistribution):
     def __init__(
         self, n_modes, dim, loc=None, scale=None, weights=None, trainable=True
     ):
-        """
-        Constructor
-        :param n_modes: Number of modes of the mixture model
-        :param dim: Number of dimensions of each Gaussian
-        :param loc: List of mean values
-        :param scale: List of diagonals of the covariance matrices
-        :param weights: List of mode probabilities
-        :param trainable: Flag, if true parameters will be optimized during training
+        """ Constructor
+
+        Args:
+          n_modes: Number of modes of the mixture model
+          dim: Number of dimensions of each Gaussian
+          loc: List of mean values
+          scale: List of diagonals of the covariance matrices
+          weights: List of mode probabilities
+          trainable: Flag, if true parameters will be optimized during training
         """
         super().__init__()
 
@@ -540,12 +549,13 @@ class GaussianPCA(BaseDistribution):
     """
 
     def __init__(self, dim, latent_dim=None, sigma=0.1):
-        """
-        Constructor
-        :param dim: Number of dimensions of the flow variables
-        :param latent_dim: Number of dimensions of the latent "content" variable;
+        """ Constructor
+        
+        Args:
+          dim: Number of dimensions of the flow variables
+          latent_dim: Number of dimensions of the latent "content" variable;
                            if None it is set equal to dim
-        :param sigma: Noise level
+          sigma: Noise level
         """
         super().__init__()
 

--- a/normflows/distributions/decoder.py
+++ b/normflows/distributions/decoder.py
@@ -8,8 +8,8 @@ class BaseDecoder(nn.Module):
         super().__init__()
 
     def forward(self, z):
-        """ Decodes z to x
-        
+        """Decodes z to x
+
         Args:
           z: latent variable
 
@@ -19,7 +19,7 @@ class BaseDecoder(nn.Module):
         raise NotImplementedError
 
     def log_prob(self, x, z):
-        """ Log probability
+        """Log probability
 
         Args:
           x: observable
@@ -37,8 +37,8 @@ class NNDiagGaussianDecoder(BaseDecoder):
     """
 
     def __init__(self, net):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           net: neural network parametrizing mean and standard deviation of diagonal Gaussian
         """
@@ -74,7 +74,7 @@ class NNBernoulliDecoder(BaseDecoder):
     """
 
     def __init__(self, net):
-        """ Constructor
+        """Constructor
 
         Args:
           net: neural network parametrizing mean Bernoulli (mean = sigmoid(nn_out)

--- a/normflows/distributions/decoder.py
+++ b/normflows/distributions/decoder.py
@@ -8,18 +8,25 @@ class BaseDecoder(nn.Module):
         super().__init__()
 
     def forward(self, z):
-        """
-        Decodes z to x
-        :param z: latent variable
-        :return: x, std of x
+        """ Decodes z to x
+        
+        Args:
+          z: latent variable
+
+        Returns:
+          x, std of x
         """
         raise NotImplementedError
 
     def log_prob(self, x, z):
-        """
-        :param x: observable
-        :param z: latent variable
-        :return: log(p) of x given z
+        """ Log probability
+
+        Args:
+          x: observable
+          z: latent variable
+
+        Returns:
+          log(p) of x given z
         """
         raise NotImplementedError
 
@@ -30,9 +37,10 @@ class NNDiagGaussianDecoder(BaseDecoder):
     """
 
     def __init__(self, net):
-        """
-        Constructor
-        :param net: neural network parametrizing mean and standard deviation of diagonal Gaussian
+        """ Constructor
+        
+        Args:
+          net: neural network parametrizing mean and standard deviation of diagonal Gaussian
         """
         super().__init__()
         self.net = net
@@ -66,9 +74,10 @@ class NNBernoulliDecoder(BaseDecoder):
     """
 
     def __init__(self, net):
-        """
-        Constructor
-        :param net: neural network parametrizing mean Bernoulli (mean = sigmoid(nn_out)
+        """ Constructor
+
+        Args:
+          net: neural network parametrizing mean Bernoulli (mean = sigmoid(nn_out)
         """
         super().__init__()
         self.net = net

--- a/normflows/distributions/encoder.py
+++ b/normflows/distributions/encoder.py
@@ -13,7 +13,7 @@ class BaseEncoder(nn.Module):
         super().__init__()
 
     def forward(self, x, num_samples=1):
-        """ 
+        """
         Args:
           x: Variable to condition on, first dimension is batch size
           num_samples: number of samples to draw per element of mini-batch
@@ -73,8 +73,8 @@ class Uniform(BaseEncoder):
 
 class ConstDiagGaussian(BaseEncoder):
     def __init__(self, loc, scale):
-        """ Multivariate Gaussian distribution with diagonal covariance and parameters being constant wrt x
-        
+        """Multivariate Gaussian distribution with diagonal covariance and parameters being constant wrt x
+
         Args:
           loc: mean vector of the distribution
           scale: vector of the standard deviations on the diagonal of the covariance matrix
@@ -133,7 +133,7 @@ class NNDiagGaussian(BaseEncoder):
     """
 
     def __init__(self, net):
-        """ Construtor
+        """Construtor
 
         Args:
           net: net computing mean (first n / 2 outputs), standard deviation (second n / 2 outputs)
@@ -166,7 +166,7 @@ class NNDiagGaussian(BaseEncoder):
 
     def log_prob(self, z, x):
         """
-        
+
         Args:
           z: Primary random variable, first dimension is batch dimension
           x: Variable to condition on, first dimension is batch dimension

--- a/normflows/distributions/encoder.py
+++ b/normflows/distributions/encoder.py
@@ -13,18 +13,25 @@ class BaseEncoder(nn.Module):
         super().__init__()
 
     def forward(self, x, num_samples=1):
-        """
-        :param x: Variable to condition on, first dimension is batch size
-        :param num_samples: number of samples to draw per element of mini-batch
-        :return: sample of z for x, log probability for sample
+        """ 
+        Args:
+          x: Variable to condition on, first dimension is batch size
+          num_samples: number of samples to draw per element of mini-batch
+
+        Returns
+          sample of z for x, log probability for sample
         """
         raise NotImplementedError
 
     def log_prob(self, z, x):
         """
-        :param z: Primary random variable, first dimension is batch size
-        :param x: Variable to condition on, first dimension is batch size
-        :return: log probability of z given x
+
+        Args:
+          z: Primary random variable, first dimension is batch size
+          x: Variable to condition on, first dimension is batch size
+
+        Returns:
+          log probability of z given x
         """
         raise NotImplementedError
 
@@ -66,10 +73,11 @@ class Uniform(BaseEncoder):
 
 class ConstDiagGaussian(BaseEncoder):
     def __init__(self, loc, scale):
-        """
-        Multivariate Gaussian distribution with diagonal covariance and parameters being constant wrt x
-        :param loc: mean vector of the distribution
-        :param scale: vector of the standard deviations on the diagonal of the covariance matrix
+        """ Multivariate Gaussian distribution with diagonal covariance and parameters being constant wrt x
+        
+        Args:
+          loc: mean vector of the distribution
+          scale: vector of the standard deviations on the diagonal of the covariance matrix
         """
         super().__init__()
         self.d = len(loc)
@@ -82,9 +90,12 @@ class ConstDiagGaussian(BaseEncoder):
 
     def forward(self, x=None, num_samples=1):
         """
-        :param x: Variable to condition on, will only be used to determine the batch size
-        :param num_samples: number of samples to draw per element of mini-batch
-        :return: sample of z for x, log probability for sample
+        Args:
+          x: Variable to condition on, will only be used to determine the batch size
+          num_samples: number of samples to draw per element of mini-batch
+
+        Returns:
+          sample of z for x, log probability for sample
         """
         if x is not None:
             batch_size = len(x)
@@ -99,9 +110,12 @@ class ConstDiagGaussian(BaseEncoder):
 
     def log_prob(self, z, x):
         """
-        :param z: Primary random variable, first dimension is batch dimension
-        :param x: Variable to condition on, first dimension is batch dimension
-        :return: log probability of z given x
+        Args:
+          z: Primary random variable, first dimension is batch dimension
+          x: Variable to condition on, first dimension is batch dimension
+
+        Returns:
+          log probability of z given x
         """
         if z.dim() == 1:
             z = z.unsqueeze(0)
@@ -119,18 +133,22 @@ class NNDiagGaussian(BaseEncoder):
     """
 
     def __init__(self, net):
-        """
-        Constructor
-        :param net: net computing mean (first n / 2 outputs), standard deviation (second n / 2 outputs)
+        """ Construtor
+
+        Args:
+          net: net computing mean (first n / 2 outputs), standard deviation (second n / 2 outputs)
         """
         super().__init__()
         self.net = net
 
     def forward(self, x, num_samples=1):
         """
-        :param x: Variable to condition on
-        :param num_samples: number of samples to draw per element of mini-batch
-        :return: sample of z for x, log probability for sample
+        Args:
+          x: Variable to condition on
+          num_samples: number of samples to draw per element of mini-batch
+
+        Returns:
+          sample of z for x, log probability for sample
         """
         batch_size = len(x)
         mean_std = self.net(x)
@@ -148,9 +166,13 @@ class NNDiagGaussian(BaseEncoder):
 
     def log_prob(self, z, x):
         """
-        :param z: Primary random variable, first dimension is batch dimension
-        :param x: Variable to condition on, first dimension is batch dimension
-        :return: log probability of z given x
+        
+        Args:
+          z: Primary random variable, first dimension is batch dimension
+          x: Variable to condition on, first dimension is batch dimension
+
+        Returns:
+          log probability of z given x
         """
         if z.dim() == 1:
             z = z.unsqueeze(0)

--- a/normflows/distributions/linear_interpolation.py
+++ b/normflows/distributions/linear_interpolation.py
@@ -4,8 +4,8 @@ class LinearInterpolation:
     """
 
     def __init__(self, dist1, dist2, alpha):
-        """ Constructor
-        
+        """Constructor
+
         Interpolation parameter alpha:
 
         ```

--- a/normflows/distributions/linear_interpolation.py
+++ b/normflows/distributions/linear_interpolation.py
@@ -4,12 +4,18 @@ class LinearInterpolation:
     """
 
     def __init__(self, dist1, dist2, alpha):
-        """
-        Constructor
-        :param dist1: First distribution
-        :param dist2: Second distribution
-        :param alpha: Interpolation parameter,
+        """ Constructor
+        
+        Interpolation parameter alpha:
+
+        ```
         log_p = alpha * log_p_1 + (1 - alpha) * log_p_2
+        ```
+
+        Args:
+          dist1: First distribution
+          dist2: Second distribution
+          alpha: Interpolation parameter
         """
         self.alpha = alpha
         self.dist1 = dist1

--- a/normflows/distributions/mh_proposal.py
+++ b/normflows/distributions/mh_proposal.py
@@ -19,18 +19,27 @@ class MHProposal(nn.Module):
 
     def log_prob(self, z_, z):
         """
-        :param z_: Potential new sample
-        :param z: Previous sample
-        :return: Log probability of proposal distribution
+        Args:
+          z_: Potential new sample
+          z: Previous sample
+
+        Returns:
+          Log probability of proposal distribution
         """
         raise NotImplementedError
 
     def forward(self, z):
-        """
-        Draw samples given z and compute log probability difference
+        """ Draw samples given z and compute log probability difference
+
+        ```
         log(p(z | z_new)) - log(p(z_new | z))
-        :param z: Previous samples
-        :return: Proposal, difference of log probability ratio
+        ```
+
+        Args:
+          z: Previous samples
+
+        Returns:
+          Proposal, difference of log probability ratio
         """
         raise NotImplementedError
 
@@ -42,10 +51,11 @@ class DiagGaussianProposal(MHProposal):
     """
 
     def __init__(self, shape, scale):
-        """
-        Constructor
-        :param shape: Shape of variables to sample
-        :param scale: Standard deviation of distribution
+        """ Constructor
+        
+        Args:
+          shape: Shape of variables to sample
+          scale: Standard deviation of distribution
         """
         super().__init__()
         self.shape = shape

--- a/normflows/distributions/mh_proposal.py
+++ b/normflows/distributions/mh_proposal.py
@@ -29,7 +29,7 @@ class MHProposal(nn.Module):
         raise NotImplementedError
 
     def forward(self, z):
-        """ Draw samples given z and compute log probability difference
+        """Draw samples given z and compute log probability difference
 
         ```
         log(p(z | z_new)) - log(p(z_new | z))
@@ -51,8 +51,8 @@ class DiagGaussianProposal(MHProposal):
     """
 
     def __init__(self, shape, scale):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           shape: Shape of variables to sample
           scale: Standard deviation of distribution

--- a/normflows/distributions/prior.py
+++ b/normflows/distributions/prior.py
@@ -24,8 +24,8 @@ class ImagePrior(nn.Module):
     """
 
     def __init__(self, image, x_range=[-3, 3], y_range=[-3, 3], eps=1.0e-10):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           image: image as np matrix
           x_range: x range to position image at
@@ -69,13 +69,13 @@ class ImagePrior(nn.Module):
         return self.density[ind[:, 0], ind[:, 1]]
 
     def rejection_sampling(self, num_steps=1):
-         """Perform rejection sampling on image distribution
-        
-         Args:
-          num_steps: Number of rejection sampling steps to perform
+        """Perform rejection sampling on image distribution
 
-         Returns:
-           Accepted samples
+        Args:
+         num_steps: Number of rejection sampling steps to perform
+
+        Returns:
+          Accepted samples
         """
         z_ = torch.rand(
             (num_steps, 2), dtype=self.image.dtype, device=self.image.device
@@ -88,8 +88,8 @@ class ImagePrior(nn.Module):
         return z
 
     def sample(self, num_samples=1):
-        """ Sample from image distribution through rejection sampling
-        
+        """Sample from image distribution through rejection sampling
+
         Args:
           num_samples: Number of samples to draw
 
@@ -106,7 +106,7 @@ class ImagePrior(nn.Module):
 
 class TwoModes(PriorDistribution):
     def __init__(self, loc, scale):
-        """ Distribution 2d with two modes
+        """Distribution 2d with two modes
 
         Distribution 2d with two modes at:
         ```z[0] = -loc```  and ```z[0] = loc```
@@ -125,7 +125,7 @@ class TwoModes(PriorDistribution):
         log(p) = 1/2 * ((norm(z) - loc) / (2 * scale)) ** 2
                 - log(exp(-1/2 * ((z[0] - loc) / (3 * scale)) ** 2) + exp(-1/2 * ((z[0] + loc) / (3 * scale)) ** 2))
         ```
-        
+
         Args:
           z: value or batch of latent variable
 
@@ -146,8 +146,8 @@ class TwoModes(PriorDistribution):
 
 class Sinusoidal(PriorDistribution):
     def __init__(self, scale, period):
-        """ Distribution 2d with sinusoidal density
-        
+        """Distribution 2d with sinusoidal density
+
         Args:
           loc: distance of modes from the origin
           scale: scale of modes
@@ -157,12 +157,12 @@ class Sinusoidal(PriorDistribution):
 
     def log_prob(self, z):
         """
-        
+
         ```
         log(p) = - 1/2 * ((z[1] - w_1(z)) / (2 * scale)) ** 2
         w_1(z) = sin(2*pi / period * z[0])
         ```
-        
+
         Args:
           z: value or batch of latent variable
 
@@ -185,8 +185,8 @@ class Sinusoidal(PriorDistribution):
 
 class Sinusoidal_gap(PriorDistribution):
     def __init__(self, scale, period):
-        """ Distribution 2d with sinusoidal density with gap
-        
+        """Distribution 2d with sinusoidal density with gap
+
         Args:
           loc: distance of modes from the origin
           scale: scale of modes
@@ -229,8 +229,8 @@ class Sinusoidal_gap(PriorDistribution):
 
 class Sinusoidal_split(PriorDistribution):
     def __init__(self, scale, period):
-        """ Distribution 2d with sinusoidal density with split
-        
+        """Distribution 2d with sinusoidal density with split
+
         Args:
           loc: distance of modes from the origin
           scale: scale of modes
@@ -273,8 +273,8 @@ class Sinusoidal_split(PriorDistribution):
 
 class Smiley(PriorDistribution):
     def __init__(self, scale):
-        """ Distribution 2d of a smiley :)
-        
+        """Distribution 2d of a smiley :)
+
         Args:
           loc: distance of modes from the origin
           scale: scale of modes

--- a/normflows/distributions/prior.py
+++ b/normflows/distributions/prior.py
@@ -9,8 +9,11 @@ class PriorDistribution:
 
     def log_prob(self, z):
         """
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        Args:
+         z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         raise NotImplementedError
 
@@ -21,12 +24,13 @@ class ImagePrior(nn.Module):
     """
 
     def __init__(self, image, x_range=[-3, 3], y_range=[-3, 3], eps=1.0e-10):
-        """
-        Constructor
-        :param image: image as np matrix
-        :param x_range: x range to position image at
-        :param y_range: y range to position image at
-        :param eps: small value to add to image to avoid log(0) problems
+        """ Constructor
+        
+        Args:
+          image: image as np matrix
+          x_range: x range to position image at
+          y_range: y range to position image at
+          eps: small value to add to image to avoid log(0) problems
         """
         super().__init__()
         image_ = np.flip(image, 0).transpose() + eps
@@ -54,18 +58,24 @@ class ImagePrior(nn.Module):
 
     def log_prob(self, z):
         """
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        Args:
+          z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         z_ = torch.clamp((z - self.shift) / self.scale, max=1, min=0)
         ind = (z_ * (self.image_size - 1)).long()
         return self.density[ind[:, 0], ind[:, 1]]
 
     def rejection_sampling(self, num_steps=1):
-        """
-        Perform rejection sampling on image distribution
-        :param num_steps: Number of rejection sampling steps to perform
-        :return: Accepted samples
+         """Perform rejection sampling on image distribution
+        
+         Args:
+          num_steps: Number of rejection sampling steps to perform
+
+         Returns:
+           Accepted samples
         """
         z_ = torch.rand(
             (num_steps, 2), dtype=self.image.dtype, device=self.image.device
@@ -78,10 +88,13 @@ class ImagePrior(nn.Module):
         return z
 
     def sample(self, num_samples=1):
-        """
-        Sample from image distribution through rejection sampling
-        :param num_samples: Number of samples to draw
-        :return: Samples
+        """ Sample from image distribution through rejection sampling
+        
+        Args:
+          num_samples: Number of samples to draw
+
+        Returns:
+          Samples
         """
         z = torch.ones((0, 2), dtype=self.image.dtype, device=self.image.device)
         while len(z) < num_samples:
@@ -93,20 +106,31 @@ class ImagePrior(nn.Module):
 
 class TwoModes(PriorDistribution):
     def __init__(self, loc, scale):
-        """
-        Distribution 2d with two modes at z[0] = -loc and z[0] = loc
-        :param loc: distance of modes from the origin
-        :param scale: scale of modes
+        """ Distribution 2d with two modes
+
+        Distribution 2d with two modes at:
+        ```z[0] = -loc```  and ```z[0] = loc```
+
+        Args:
+          loc: distance of modes from the origin
+          scale: scale of modes
         """
         self.loc = loc
         self.scale = scale
 
     def log_prob(self, z):
         """
+
+        ```
         log(p) = 1/2 * ((norm(z) - loc) / (2 * scale)) ** 2
                 - log(exp(-1/2 * ((z[0] - loc) / (3 * scale)) ** 2) + exp(-1/2 * ((z[0] + loc) / (3 * scale)) ** 2))
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        ```
+        
+        Args:
+          z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         a = torch.abs(z[:, 0])
         eps = torch.abs(torch.tensor(self.loc))
@@ -122,20 +146,28 @@ class TwoModes(PriorDistribution):
 
 class Sinusoidal(PriorDistribution):
     def __init__(self, scale, period):
-        """
-        Distribution 2d with sinusoidal density
-        :param loc: distance of modes from the origin
-        :param scale: scale of modes
+        """ Distribution 2d with sinusoidal density
+        
+        Args:
+          loc: distance of modes from the origin
+          scale: scale of modes
         """
         self.scale = scale
         self.period = period
 
     def log_prob(self, z):
         """
+        
+        ```
         log(p) = - 1/2 * ((z[1] - w_1(z)) / (2 * scale)) ** 2
         w_1(z) = sin(2*pi / period * z[0])
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        ```
+        
+        Args:
+          z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         if z.dim() > 1:
             z_ = z.permute((z.dim() - 1,) + tuple(range(0, z.dim() - 1)))
@@ -153,10 +185,11 @@ class Sinusoidal(PriorDistribution):
 
 class Sinusoidal_gap(PriorDistribution):
     def __init__(self, scale, period):
-        """
-        Distribution 2d with sinusoidal density with gap
-        :param loc: distance of modes from the origin
-        :param scale: scale of modes
+        """ Distribution 2d with sinusoidal density with gap
+        
+        Args:
+          loc: distance of modes from the origin
+          scale: scale of modes
         """
         self.scale = scale
         self.period = period
@@ -166,8 +199,11 @@ class Sinusoidal_gap(PriorDistribution):
 
     def log_prob(self, z):
         """
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        Args:
+          z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         if z.dim() > 1:
             z_ = z.permute((z.dim() - 1,) + tuple(range(0, z.dim() - 1)))
@@ -193,10 +229,11 @@ class Sinusoidal_gap(PriorDistribution):
 
 class Sinusoidal_split(PriorDistribution):
     def __init__(self, scale, period):
-        """
-        Distribution 2d with sinusoidal density with split
-        :param loc: distance of modes from the origin
-        :param scale: scale of modes
+        """ Distribution 2d with sinusoidal density with split
+        
+        Args:
+          loc: distance of modes from the origin
+          scale: scale of modes
         """
         self.scale = scale
         self.period = period
@@ -206,8 +243,11 @@ class Sinusoidal_split(PriorDistribution):
 
     def log_prob(self, z):
         """
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        Args:
+          z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         if z.dim() > 1:
             z_ = z.permute((z.dim() - 1,) + tuple(range(0, z.dim() - 1)))
@@ -233,18 +273,22 @@ class Sinusoidal_split(PriorDistribution):
 
 class Smiley(PriorDistribution):
     def __init__(self, scale):
-        """
-        Distribution 2d of a smiley :)
-        :param loc: distance of modes from the origin
-        :param scale: scale of modes
+        """ Distribution 2d of a smiley :)
+        
+        Args:
+          loc: distance of modes from the origin
+          scale: scale of modes
         """
         self.scale = scale
         self.loc = 2.0
 
     def log_prob(self, z):
         """
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        Args:
+          z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         if z.dim() > 1:
             z_ = z.permute((z.dim() - 1,) + tuple(range(0, z.dim() - 1)))

--- a/normflows/distributions/target.py
+++ b/normflows/distributions/target.py
@@ -9,8 +9,8 @@ class Target(nn.Module):
     """
 
     def __init__(self, prop_scale=torch.tensor(6.0), prop_shift=torch.tensor(-3.0)):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           prop_scale: Scale for the uniform proposal
           prop_shift: Shift for the uniform proposal
@@ -30,8 +30,8 @@ class Target(nn.Module):
         raise NotImplementedError("The log probability is not implemented yet.")
 
     def rejection_sampling(self, num_steps=1):
-        """ Perform rejection sampling on image distribution
-        
+        """Perform rejection sampling on image distribution
+
         Args:
           num_steps: Number of rejection sampling steps to perform
 
@@ -53,8 +53,8 @@ class Target(nn.Module):
         return z
 
     def sample(self, num_samples=1):
-        """ Sample from image distribution through rejection sampling
-        
+        """Sample from image distribution through rejection sampling
+
         Args:
           num_samples: Number of samples to draw
 
@@ -110,8 +110,8 @@ class CircularGaussianMixture(nn.Module):
     """
 
     def __init__(self, n_modes=8):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           n_modes: Number of modes
         """

--- a/normflows/distributions/target.py
+++ b/normflows/distributions/target.py
@@ -9,10 +9,11 @@ class Target(nn.Module):
     """
 
     def __init__(self, prop_scale=torch.tensor(6.0), prop_shift=torch.tensor(-3.0)):
-        """
-        Constructor
-        :param prop_scale: Scale for the uniform proposal
-        :param prop_shift: Shift for the uniform proposal
+        """ Constructor
+        
+        Args:
+          prop_scale: Scale for the uniform proposal
+          prop_shift: Shift for the uniform proposal
         """
         super().__init__()
         self.register_buffer("prop_scale", prop_scale)
@@ -20,16 +21,22 @@ class Target(nn.Module):
 
     def log_prob(self, z):
         """
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        Args:
+          z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         raise NotImplementedError("The log probability is not implemented yet.")
 
     def rejection_sampling(self, num_steps=1):
-        """
-        Perform rejection sampling on image distribution
-        :param num_steps: Number of rejection sampling steps to perform
-        :return: Accepted samples
+        """ Perform rejection sampling on image distribution
+        
+        Args:
+          num_steps: Number of rejection sampling steps to perform
+
+        Returns:
+          Accepted samples
         """
         eps = torch.rand(
             (num_steps, self.n_dims),
@@ -46,10 +53,13 @@ class Target(nn.Module):
         return z
 
     def sample(self, num_samples=1):
-        """
-        Sample from image distribution through rejection sampling
-        :param num_samples: Number of samples to draw
-        :return: Samples
+        """ Sample from image distribution through rejection sampling
+        
+        Args:
+          num_samples: Number of samples to draw
+
+        Returns:
+          Samples
         """
         z = torch.zeros(
             (0, self.n_dims), dtype=self.prop_scale.dtype, device=self.prop_scale.device
@@ -73,11 +83,17 @@ class TwoMoons(Target):
 
     def log_prob(self, z):
         """
+        ```
         log(p) = - 1/2 * ((norm(z) - 2) / 0.2) ** 2
                  + log(  exp(-1/2 * ((z[0] - 2) / 0.3) ** 2)
                        + exp(-1/2 * ((z[0] + 2) / 0.3) ** 2))
-        :param z: value or batch of latent variable
-        :return: log probability of the distribution for z
+        ```
+
+        Args:
+          z: value or batch of latent variable
+
+        Returns:
+          log probability of the distribution for z
         """
         a = torch.abs(z[:, 0])
         log_prob = (
@@ -94,9 +110,10 @@ class CircularGaussianMixture(nn.Module):
     """
 
     def __init__(self, n_modes=8):
-        """
-        Constructor
-        :param n_modes: Number of modes
+        """ Constructor
+        
+        Args:
+          n_modes: Number of modes
         """
         super(CircularGaussianMixture, self).__init__()
         self.n_modes = n_modes

--- a/normflows/flows/affine/autoregressive.py
+++ b/normflows/flows/affine/autoregressive.py
@@ -13,7 +13,7 @@ class Autoregressive(Flow):
     The parameters of each invertible elementwise transformation can be functions of previous input
     variables, but they must not depend on the current or any following input variables.
 
-    NOTE: Calculating the inverse transform is D times slower than calculating the
+    **NOTE** Calculating the inverse transform is D times slower than calculating the
     forward transform, where D is the dimensionality of the input to the transform.
     """
 

--- a/normflows/flows/affine/coupling.py
+++ b/normflows/flows/affine/coupling.py
@@ -13,13 +13,13 @@ class AffineConstFlow(Flow):
     """
 
     def __init__(self, shape, scale=True, shift=True):
-        """
-        Constructor
-        :param shape: Shape of the coupling layer
-        :param scale: Flag whether to apply scaling
-        :param shift: Flag whether to apply shift
-        :param logscale_factor: Optional factor which can be used to control
-        the scale of the log scale factor
+        """ Constructor
+        
+        Args:
+          shape: Shape of the coupling layer
+          scale: Flag whether to apply scaling
+          shift: Flag whether to apply shift
+          logscale_factor: Optional factor which can be used to control the scale of the log scale factor
         """
         super().__init__()
         if scale:
@@ -100,13 +100,12 @@ class AffineCoupling(Flow):
     """
 
     def __init__(self, param_map, scale=True, scale_map="exp"):
-        """
-        Constructor
-        :param param_map: Maps features to shift and scale parameter (if applicable)
-        :param scale: Flag whether scale shall be applied
-        :param scale_map: Map to be applied to the scale parameter, can be 'exp' as in
-        RealNVP or 'sigmoid' as in Glow, 'sigmoid_inv' uses multiplicative sigmoid
-        scale when sampling from the model
+        """ Constructor
+        
+        Args:
+          param_map: Maps features to shift and scale parameter (if applicable)
+          scale: Flag whether scale shall be applied
+          scale_map: Map to be applied to the scale parameter, can be 'exp' as in RealNVP or 'sigmoid' as in Glow, 'sigmoid_inv' uses multiplicative sigmoid scale when sampling from the model
         """
         super().__init__()
         self.add_module("param_map", param_map)
@@ -115,9 +114,12 @@ class AffineCoupling(Flow):
 
     def forward(self, z):
         """
-        z is a list of z1 and z2; z = [z1, z2]
+        z is a list of z1 and z2; ```z = [z1, z2]```
         z1 is left constant and affine map is applied to z2 with parameters depending
         on z1
+
+        Args:
+          z
         """
         z1, z2 = z
         param = self.param_map(z1)
@@ -168,21 +170,25 @@ class AffineCoupling(Flow):
 
 
 class MaskedAffineFlow(Flow):
-    """
-    RealNVP as introduced in arXiv: 1605.08803
-    Masked affine flow f(z) = b * z + (1 - b) * (z * exp(s(b * z)) + t)
-    class AffineHalfFlow(Flow): is MaskedAffineFlow with alternating bit mask
-    NICE is AffineFlow with only shifts (volume preserving)
+    """ RealNVP as introduced in [arXiv: 1605.08803](https://arxiv.org/abs/1605.08803)
+    
+    Masked affine flow:
+
+    ```
+    f(z) = b * z + (1 - b) * (z * exp(s(b * z)) + t)
+    ```
+
+    - class AffineHalfFlow(Flow): is MaskedAffineFlow with alternating bit mask
+    - NICE is AffineFlow with only shifts (volume preserving)
     """
 
     def __init__(self, b, t=None, s=None):
-        """
-        Constructor
-        :param b: mask for features, i.e. tensor of same size as latent data point filled with 0s and 1s
-        :param t: translation mapping, i.e. neural network, where first input dimension is batch dim,
-        if None no translation is applied
-        :param s: scale mapping, i.e. neural network, where first input dimension is batch dim,
-        if None no scale is applied
+        """ Constructor
+        
+        Args:
+          b: mask for features, i.e. tensor of same size as latent data point filled with 0s and 1s
+          t: translation mapping, i.e. neural network, where first input dimension is batch dim, if None no translation is applied
+          s: scale mapping, i.e. neural network, where first input dimension is batch dim, if None no scale is applied
         """
         super().__init__()
         self.b_cpu = b.view(1, *b.size())
@@ -227,13 +233,13 @@ class AffineCouplingBlock(Flow):
     """
 
     def __init__(self, param_map, scale=True, scale_map="exp", split_mode="channel"):
-        """
-        Constructor
-        :param param_map: Maps features to shift and scale parameter (if applicable)
-        :param scale: Flag whether scale shall be applied
-        :param scale_map: Map to be applied to the scale parameter, can be 'exp' as in
-        RealNVP or 'sigmoid' as in Glow
-        :param split_mode: Splitting mode, for possible values see Split class
+        """ Constructor
+        
+        Args:
+          param_map: Maps features to shift and scale parameter (if applicable)
+          scale: Flag whether scale shall be applied
+          scale_map: Map to be applied to the scale parameter, can be 'exp' as in RealNVP or 'sigmoid' as in Glow
+          split_mode: Splitting mode, for possible values see Split class
         """
         super().__init__()
         self.flows = nn.ModuleList([])

--- a/normflows/flows/affine/coupling.py
+++ b/normflows/flows/affine/coupling.py
@@ -13,8 +13,8 @@ class AffineConstFlow(Flow):
     """
 
     def __init__(self, shape, scale=True, shift=True):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           shape: Shape of the coupling layer
           scale: Flag whether to apply scaling
@@ -100,8 +100,8 @@ class AffineCoupling(Flow):
     """
 
     def __init__(self, param_map, scale=True, scale_map="exp"):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           param_map: Maps features to shift and scale parameter (if applicable)
           scale: Flag whether scale shall be applied
@@ -170,8 +170,8 @@ class AffineCoupling(Flow):
 
 
 class MaskedAffineFlow(Flow):
-    """ RealNVP as introduced in [arXiv: 1605.08803](https://arxiv.org/abs/1605.08803)
-    
+    """RealNVP as introduced in [arXiv: 1605.08803](https://arxiv.org/abs/1605.08803)
+
     Masked affine flow:
 
     ```
@@ -183,8 +183,8 @@ class MaskedAffineFlow(Flow):
     """
 
     def __init__(self, b, t=None, s=None):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           b: mask for features, i.e. tensor of same size as latent data point filled with 0s and 1s
           t: translation mapping, i.e. neural network, where first input dimension is batch dim, if None no translation is applied
@@ -233,8 +233,8 @@ class AffineCouplingBlock(Flow):
     """
 
     def __init__(self, param_map, scale=True, scale_map="exp", split_mode="channel"):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           param_map: Maps features to shift and scale parameter (if applicable)
           scale: Flag whether scale shall be applied

--- a/normflows/flows/affine/glow.py
+++ b/normflows/flows/affine/glow.py
@@ -9,12 +9,13 @@ from ... import nets
 
 
 class GlowBlock(Flow):
-    """
-    Glow: Generative Flow with Invertible 1×1 Convolutions, arXiv: 1807.03039
+    """ Glow: Generative Flow with Invertible 1×1 Convolutions, [arXiv: 1807.03039](https://arxiv.org/abs/1807.03039)
+    
     One Block of the Glow model, comprised of
-    MaskedAffineFlow (affine coupling layer
-    Invertible1x1Conv (dropped if there is only one channel)
-    ActNorm (first batch used for initialization)
+
+    - MaskedAffineFlow (affine coupling layer)
+    - Invertible1x1Conv (dropped if there is only one channel)
+    - ActNorm (first batch used for initialization)
     """
 
     def __init__(
@@ -29,20 +30,18 @@ class GlowBlock(Flow):
         use_lu=True,
         net_actnorm=False,
     ):
-        """
-        Constructor
-        :param channels: Number of channels of the data
-        :param hidden_channels: number of channels in the hidden layer of the ConvNet
-        :param scale: Flag, whether to include scale in affine coupling layer
-        :param scale_map: Map to be applied to the scale parameter, can be 'exp' as in
-        RealNVP or 'sigmoid' as in Glow
-        :param split_mode: Splitting mode, for possible values see Split class
-        :param leaky: Leaky parameter of LeakyReLUs of ConvNet2d
-        :param init_zeros: Flag whether to initialize last conv layer with zeros
-        :param use_lu: Flag whether to parametrize weights through the LU decomposition
-        in invertible 1x1 convolution layers
-        :param logscale_factor: Factor which can be used to control the scale of
-        the log scale factor, see https://github.com/openai/glow
+        """ Constructor
+
+        Args:
+          channels: Number of channels of the data
+          hidden_channels: number of channels in the hidden layer of the ConvNet
+          scale: Flag, whether to include scale in affine coupling layer
+          scale_map: Map to be applied to the scale parameter, can be 'exp' as in RealNVP or 'sigmoid' as in Glow
+          split_mode: Splitting mode, for possible values see Split class
+          leaky: Leaky parameter of LeakyReLUs of ConvNet2d
+          init_zeros: Flag whether to initialize last conv layer with zeros
+          use_lu: Flag whether to parametrize weights through the LU decomposition in invertible 1x1 convolution layers
+          logscale_factor: Factor which can be used to control the scale of the log scale factor, see [source](https://github.com/openai/glow)
         """
         super().__init__()
         self.flows = nn.ModuleList([])

--- a/normflows/flows/affine/glow.py
+++ b/normflows/flows/affine/glow.py
@@ -9,8 +9,8 @@ from ... import nets
 
 
 class GlowBlock(Flow):
-    """ Glow: Generative Flow with Invertible 1×1 Convolutions, [arXiv: 1807.03039](https://arxiv.org/abs/1807.03039)
-    
+    """Glow: Generative Flow with Invertible 1×1 Convolutions, [arXiv: 1807.03039](https://arxiv.org/abs/1807.03039)
+
     One Block of the Glow model, comprised of
 
     - MaskedAffineFlow (affine coupling layer)
@@ -30,7 +30,7 @@ class GlowBlock(Flow):
         use_lu=True,
         net_actnorm=False,
     ):
-        """ Constructor
+        """Constructor
 
         Args:
           channels: Number of channels of the data

--- a/normflows/flows/base.py
+++ b/normflows/flows/base.py
@@ -12,8 +12,11 @@ class Flow(nn.Module):
 
     def forward(self, z):
         """
-        :param z: input variable, first dimension is batch dim
-        :return: transformed z and log of absolute determinant
+        Args:
+          z: input variable, first dimension is batch dim
+        
+        Returns:
+          transformed z and log of absolute determinant
         """
         raise NotImplementedError("Forward pass has not been implemented.")
 
@@ -27,9 +30,10 @@ class Reverse(Flow):
     """
 
     def __init__(self, flow):
-        """
-        Constructor
-        :param flow: Flow layer to be reversed
+        """ Constructor
+        
+        Args:
+          flow: Flow layer to be reversed
         """
         super().__init__()
         self.flow = flow
@@ -47,9 +51,10 @@ class Composite(Flow):
     """
 
     def __init__(self, flows):
-        """
-        Constructor
-        :param flows: Iterable of flows to composite
+        """ Constructor
+        
+        Args:
+          flows: Iterable of flows to composite
         """
         super().__init__()
         self._flows = nn.ModuleList(flows)

--- a/normflows/flows/base.py
+++ b/normflows/flows/base.py
@@ -14,7 +14,7 @@ class Flow(nn.Module):
         """
         Args:
           z: input variable, first dimension is batch dim
-        
+
         Returns:
           transformed z and log of absolute determinant
         """
@@ -30,8 +30,8 @@ class Reverse(Flow):
     """
 
     def __init__(self, flow):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           flow: Flow layer to be reversed
         """
@@ -51,8 +51,8 @@ class Composite(Flow):
     """
 
     def __init__(self, flows):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           flows: Iterable of flows to composite
         """

--- a/normflows/flows/mixing.py
+++ b/normflows/flows/mixing.py
@@ -12,7 +12,7 @@ class Permute(Flow):
     """
 
     def __init__(self, num_channels, mode="shuffle"):
-        """ Constructor
+        """Constructor
 
         Args:
           num_channel: Number of channels
@@ -61,8 +61,8 @@ class Invertible1x1Conv(Flow):
     """
 
     def __init__(self, num_channels, use_lu=False):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           num_channels: Number of channels of the data
           use_lu: Flag whether to parametrize weights through the LU decomposition
@@ -140,7 +140,7 @@ class InvertibleAffine(Flow):
     """
 
     def __init__(self, num_channels, use_lu=True):
-        """ Constructor
+        """Constructor
 
         Args:
           num_channels: Number of channels of the data
@@ -421,7 +421,7 @@ class _LULinear(_Linear):
         ```
 
         where:
-        
+
         ```
             D = num of features
             N = num of inputs
@@ -510,7 +510,7 @@ class _LULinear(_Linear):
     def logabsdet(self):
         """
         Cost:
-        
+
         ```
             logabsdet = O(D)
         ```
@@ -531,8 +531,8 @@ class LULinearPermute(Flow):
     """
 
     def __init__(self, num_channels, identity_init=True):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           num_channels: Number of dimensions of the data
           identity_init: Flag, whether to initialize linear transform as identity matrix

--- a/normflows/flows/mixing.py
+++ b/normflows/flows/mixing.py
@@ -12,11 +12,11 @@ class Permute(Flow):
     """
 
     def __init__(self, num_channels, mode="shuffle"):
-        """
-        Constructor
-        :param num_channel: Number of channels
-        :param mode: Mode of permuting features, can be shuffle for
-        random permutation or swap for interchanging upper and lower part
+        """ Constructor
+
+        Args:
+          num_channel: Number of channels
+          mode: Mode of permuting features, can be shuffle for random permutation or swap for interchanging upper and lower part
         """
         super().__init__()
         self.mode = mode
@@ -61,10 +61,11 @@ class Invertible1x1Conv(Flow):
     """
 
     def __init__(self, num_channels, use_lu=False):
-        """
-        Constructor
-        :param num_channels: Number of channels of the data
-        :param use_lu: Flag whether to parametrize weights through the LU decomposition
+        """ Constructor
+        
+        Args:
+          num_channels: Number of channels of the data
+          use_lu: Flag whether to parametrize weights through the LU decomposition
         """
         super().__init__()
         self.num_channels = num_channels
@@ -139,11 +140,11 @@ class InvertibleAffine(Flow):
     """
 
     def __init__(self, num_channels, use_lu=True):
-        """
-        Constructor
-        :param num_channels: Number of channels of the data
-        :param use_lu: Flag whether to parametrize weights through the
-        LU decomposition
+        """ Constructor
+
+        Args:
+          num_channels: Number of channels of the data
+          use_lu: Flag whether to parametrize weights through the LU decomposition
         """
         super().__init__()
         self.num_channels = num_channels
@@ -411,12 +412,20 @@ class _LULinear(_Linear):
         return lower, upper
 
     def forward_no_cache(self, inputs):
-        """Cost:
+        """
+        Cost:
+
+        ```
             output = O(D^2N)
             logabsdet = O(D)
+        ```
+
         where:
+        
+        ```
             D = num of features
             N = num of inputs
+        ```
         """
         lower, upper = self._create_lower_upper()
         outputs = F.linear(inputs, upper)
@@ -425,12 +434,20 @@ class _LULinear(_Linear):
         return outputs, logabsdet
 
     def inverse_no_cache(self, inputs):
-        """Cost:
+        """
+        Cost:
+
+        ```
             output = O(D^2N)
             logabsdet = O(D)
+        ```
+
         where:
+
+        ```
             D = num of features
             N = num of inputs
+        ```
         """
         lower, upper = self._create_lower_upper()
         outputs = inputs - self.bias
@@ -448,19 +465,35 @@ class _LULinear(_Linear):
         return outputs, logabsdet
 
     def weight(self):
-        """Cost:
+        """
+        Cost:
+
+        ```
             weight = O(D^3)
+        ```
+
         where:
+
+        ```
             D = num of features
+        ```
         """
         lower, upper = self._create_lower_upper()
         return lower @ upper
 
     def weight_inverse(self):
-        """Cost:
+        """
+        Cost:
+
+        ```
             inverse = O(D^3)
+        ```
+
         where:
+
+        ```
             D = num of features
+        ```
         """
         lower, upper = self._create_lower_upper()
         identity = torch.eye(self.features, self.features)
@@ -475,10 +508,18 @@ class _LULinear(_Linear):
         return F.softplus(self.unconstrained_upper_diag) + self.eps
 
     def logabsdet(self):
-        """Cost:
+        """
+        Cost:
+        
+        ```
             logabsdet = O(D)
+        ```
+
         where:
+
+        ```
             D = num of features
+        ```
         """
         return torch.sum(torch.log(self.upper_diag))
 
@@ -490,11 +531,11 @@ class LULinearPermute(Flow):
     """
 
     def __init__(self, num_channels, identity_init=True):
-        """
-        Constructor
-        :param num_channels: Number of dimensions of the data
-        :param identity_init: Flag, whether to initialize linear
-        transform as identity matrix
+        """ Constructor
+        
+        Args:
+          num_channels: Number of dimensions of the data
+          identity_init: Flag, whether to initialize linear transform as identity matrix
         """
         # Initialize
         super().__init__()

--- a/normflows/flows/neural_spline/coupling.py
+++ b/normflows/flows/neural_spline/coupling.py
@@ -20,8 +20,8 @@ class Coupling(Flow):
     provided 1D mask."""
 
     def __init__(self, mask, transform_net_create_fn, unconditional_transform=None):
-        """ Constructor.
-        
+        """Constructor.
+
         mask: a 1-dim tensor, tuple or list. It indexes inputs as follows:
 
         - if `mask[i] > 0`, `input[i]` will be transformed.

--- a/normflows/flows/neural_spline/coupling.py
+++ b/normflows/flows/neural_spline/coupling.py
@@ -20,13 +20,15 @@ class Coupling(Flow):
     provided 1D mask."""
 
     def __init__(self, mask, transform_net_create_fn, unconditional_transform=None):
-        """
-        Constructor.
+        """ Constructor.
+        
+        mask: a 1-dim tensor, tuple or list. It indexes inputs as follows:
+
+        - if `mask[i] > 0`, `input[i]` will be transformed.
+        - if `mask[i] <= 0`, `input[i]` will be passed unchanged.
 
         Args:
-            mask: a 1-dim tensor, tuple or list. It indexes inputs as follows:
-                * If `mask[i] > 0`, `input[i]` will be transformed.
-                * If `mask[i] <= 0`, `input[i]` will be passed unchanged.
+          mask
         """
         mask = torch.as_tensor(mask)
         if mask.dim() != 1:

--- a/normflows/flows/neural_spline/wrapper.py
+++ b/normflows/flows/neural_spline/wrapper.py
@@ -14,7 +14,7 @@ from ...utils.splines import DEFAULT_MIN_DERIVATIVE
 class CoupledRationalQuadraticSpline(Flow):
     """
     Neural spline flow coupling layer, wrapper for the implementation
-    of Durkan et al., see https://github.com/bayesiains/nsf
+    of Durkan et al., see [source](https://github.com/bayesiains/nsf)
     """
 
     def __init__(
@@ -29,28 +29,18 @@ class CoupledRationalQuadraticSpline(Flow):
         dropout_probability=0.0,
         reverse_mask=False,
     ):
-        """
-        Constructor
-        :param num_input_channels: Flow dimension
-        :type num_input_channels: Int
-        :param num_blocks: Number of residual blocks of the parameter NN
-        :type num_blocks: Int
-        :param num_hidden_channels: Number of hidden units of the NN
-        :type num_hidden_channels: Int
-        :param num_bins: Number of bins
-        :type num_bins: Int
-        :param tails: Behaviour of the tails of the distribution,
-        can be linear, circular for periodic distribution, or None for
-        distribution on the compact interval
-        :type tails: String
-        :param tail_bound: Bound of the spline tails
-        :type tail_bound: Float
-        :param activation: Activation function
-        :type activation: torch module
-        :param dropout_probability: Dropout probability of the NN
-        :type dropout_probability: Float
-        :param reverse_mask: Flag whether the reverse mask should be used
-        :type reverse_mask: Boolean
+        """ Constructor
+        
+        Args:
+          num_input_channels (int): Flow dimension
+          num_blocks (int): Number of residual blocks of the parameter NN
+          num_hidden_channels (int): Number of hidden units of the NN
+          num_bins (int): Number of bins
+          tails (str): Behaviour of the tails of the distribution, can be linear, circular for periodic distribution, or None for distribution on the compact interval
+          tail_bound (float): Bound of the spline tails
+          activation (torch module): Activation function
+          dropout_probability (float): Dropout probability of the NN
+          reverse_mask (bool): Flag whether the reverse mask should be used
         """
         super().__init__()
 
@@ -104,30 +94,20 @@ class CircularCoupledRationalQuadraticSpline(Flow):
         mask=None,
         init_identity=True,
     ):
-        """
-        Constructor
-        :param num_input_channels: Flow dimension
-        :type num_input_channels: Int
-        :param num_blocks: Number of residual blocks of the parameter NN
-        :type num_blocks: Int
-        :param num_hidden_channels: Number of hidden units of the NN
-        :type num_hidden_channels: Int
-        :param ind_circ: Indices of the circular coordinates
-        :type ind_circ: Iterable
-        :param num_bins: Number of bins
-        :type num_bins: Int
-        :param tail_bound: Bound of the spline tails
-        :type tail_bound: Float or Iterable
-        :param activation: Activation function
-        :type activation: torch module
-        :param dropout_probability: Dropout probability of the NN
-        :type dropout_probability: Float
-        :param reverse_mask: Flag whether the reverse mask should be used
-        :type reverse_mask: Boolean
-        :param mask: Mask to be used, alternating masked generated is None
-        :param mask: torch tensor
-        :param init_identity: Flag, initialize transform as identity
-        :type init_identity: Boolean
+        """ Constructor
+
+        Args:
+          num_input_channels (int): Flow dimension
+          num_blocks (int): Number of residual blocks of the parameter NN
+          num_hidden_channels (int): Number of hidden units of the NN
+          ind_circ (Iterable): Indices of the circular coordinates
+          num_bins (int): Number of bins
+          tail_bound (float or Iterable): Bound of the spline tails
+          activation (torch module): Activation function
+          dropout_probability (float): Dropout probability of the NN
+          reverse_mask (bool): Flag whether the reverse mask should be used
+          mask (torch tensor): Mask to be used, alternating masked generated is None
+          init_identity (bool): Flag, initialize transform as identity
         """
         super().__init__()
 
@@ -194,7 +174,7 @@ class CircularCoupledRationalQuadraticSpline(Flow):
 class AutoregressiveRationalQuadraticSpline(Flow):
     """
     Neural spline flow coupling layer, wrapper for the implementation
-    of Durkan et al., see https://github.com/bayesiains/nsf
+    of Durkan et al., see [sources](https://github.com/bayesiains/nsf)
     """
 
     def __init__(
@@ -209,26 +189,18 @@ class AutoregressiveRationalQuadraticSpline(Flow):
         permute_mask=False,
         init_identity=True,
     ):
-        """
-        Constructor
-        :param num_input_channels: Flow dimension
-        :type num_input_channels: Int
-        :param num_blocks: Number of residual blocks of the parameter NN
-        :type num_blocks: Int
-        :param num_hidden_channels: Number of hidden units of the NN
-        :type num_hidden_channels: Int
-        :param num_bins: Number of bins
-        :type num_bins: Int
-        :param tail_bound: Bound of the spline tails
-        :type tail_bound: Int
-        :param activation: Activation function
-        :type activation: torch module
-        :param dropout_probability: Dropout probability of the NN
-        :type dropout_probability: Float
-        :param permute_mask: Flag, permutes the mask of the NN
-        :type permute_mask: Boolean
-        :param init_identity: Flag, initialize transform as identity
-        :type init_identity: Boolean
+        """ Constructor
+
+        Args:
+          num_input_channels (int): Flow dimension
+          num_blocks (int): Number of residual blocks of the parameter NN
+          num_hidden_channels (int): Number of hidden units of the NN
+          num_bins (int): Number of bins
+          tail_bound (int): Bound of the spline tails
+          activation (torch module): Activation function
+          dropout_probability (float): Dropout probability of the NN
+          permute_mask (bool): Flag, permutes the mask of the NN
+          init_identity (bool): Flag, initialize transform as identity
         """
         super().__init__()
 
@@ -261,7 +233,7 @@ class AutoregressiveRationalQuadraticSpline(Flow):
 class CircularAutoregressiveRationalQuadraticSpline(Flow):
     """
     Neural spline flow coupling layer, wrapper for the implementation
-    of Durkan et al., see https://github.com/bayesiains/nsf
+    of Durkan et al., see [sources](https://github.com/bayesiains/nsf)
     """
 
     def __init__(
@@ -277,28 +249,19 @@ class CircularAutoregressiveRationalQuadraticSpline(Flow):
         permute_mask=True,
         init_identity=True,
     ):
-        """
-        Constructor
-        :param num_input_channels: Flow dimension
-        :type num_input_channels: Int
-        :param num_blocks: Number of residual blocks of the parameter NN
-        :type num_blocks: Int
-        :param num_hidden_channels: Number of hidden units of the NN
-        :type num_hidden_channels: Int
-        :param ind_circ: Indices of the circular coordinates
-        :type ind_circ: Iterable
-        :param num_bins: Number of bins
-        :type num_bins: Int
-        :param tail_bound: Bound of the spline tails
-        :type tail_bound: Int
-        :param activation: Activation function
-        :type activation: torch module
-        :param dropout_probability: Dropout probability of the NN
-        :type dropout_probability: Float
-        :param permute_mask: Flag, permutes the mask of the NN
-        :type permute_mask: Boolean
-        :param init_identity: Flag, initialize transform as identity
-        :type init_identity: Boolean
+        """ Constructor
+
+        Args:
+          num_input_channels (int): Flow dimension
+          num_blocks (int): Number of residual blocks of the parameter NN
+          num_hidden_channels (int): Number of hidden units of the NN
+          ind_circ (Iterable): Indices of the circular coordinates
+          num_bins (int): Number of bins
+          tail_bound (int): Bound of the spline tails
+          activation (torch module): Activation function
+          dropout_probability (float): Dropout probability of the NN
+          permute_mask (bool): Flag, permutes the mask of the NN
+          init_identity (bool): Flag, initialize transform as identity
         """
         super().__init__()
 

--- a/normflows/flows/neural_spline/wrapper.py
+++ b/normflows/flows/neural_spline/wrapper.py
@@ -29,8 +29,8 @@ class CoupledRationalQuadraticSpline(Flow):
         dropout_probability=0.0,
         reverse_mask=False,
     ):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           num_input_channels (int): Flow dimension
           num_blocks (int): Number of residual blocks of the parameter NN
@@ -94,7 +94,7 @@ class CircularCoupledRationalQuadraticSpline(Flow):
         mask=None,
         init_identity=True,
     ):
-        """ Constructor
+        """Constructor
 
         Args:
           num_input_channels (int): Flow dimension
@@ -189,7 +189,7 @@ class AutoregressiveRationalQuadraticSpline(Flow):
         permute_mask=False,
         init_identity=True,
     ):
-        """ Constructor
+        """Constructor
 
         Args:
           num_input_channels (int): Flow dimension
@@ -249,7 +249,7 @@ class CircularAutoregressiveRationalQuadraticSpline(Flow):
         permute_mask=True,
         init_identity=True,
     ):
-        """ Constructor
+        """Constructor
 
         Args:
           num_input_channels (int): Flow dimension

--- a/normflows/flows/normalization.py
+++ b/normflows/flows/normalization.py
@@ -41,7 +41,7 @@ class ActNorm(AffineConstFlow):
 
 class BatchNorm(Flow):
     """
-    Batch Normalization with out considering the derivatives of the batch statistics, see arXiv: 1605.08803
+    Batch Normalization with out considering the derivatives of the batch statistics, see [arXiv: 1605.08803](https://arxiv.org/abs/1605.08803)
     """
 
     def __init__(self, eps=1.0e-10):

--- a/normflows/flows/periodic.py
+++ b/normflows/flows/periodic.py
@@ -9,10 +9,10 @@ class PeriodicWrap(Flow):
     """
 
     def __init__(self, ind, bound=1.0):
-        """
-        Constructor
-        :param ind: Iterable, indices of coordinates to be mapped
-        :param bound: Float or iterable, bound of interval
+        """ Constructor
+        
+          ind: Iterable, indices of coordinates to be mapped
+          bound: Float or iterable, bound of interval
         """
         super().__init__()
         self.ind = ind
@@ -38,11 +38,12 @@ class PeriodicShift(Flow):
     """
 
     def __init__(self, ind, bound=1.0, shift=0.0):
-        """
-        Constructor
-        :param ind: Iterable, indices of coordinates to be mapped
-        :param bound: Float or iterable, bound of interval
-        :param shift: Tensor, shift to be applied
+        """ Constructor
+        
+        Args:
+          ind: Iterable, indices of coordinates to be mapped
+          bound: Float or iterable, bound of interval
+          shift: Tensor, shift to be applied
         """
         super().__init__()
         self.ind = ind

--- a/normflows/flows/periodic.py
+++ b/normflows/flows/periodic.py
@@ -9,10 +9,10 @@ class PeriodicWrap(Flow):
     """
 
     def __init__(self, ind, bound=1.0):
-        """ Constructor
-        
-          ind: Iterable, indices of coordinates to be mapped
-          bound: Float or iterable, bound of interval
+        """Constructor
+
+        ind: Iterable, indices of coordinates to be mapped
+        bound: Float or iterable, bound of interval
         """
         super().__init__()
         self.ind = ind
@@ -38,8 +38,8 @@ class PeriodicShift(Flow):
     """
 
     def __init__(self, ind, bound=1.0, shift=0.0):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           ind: Iterable, indices of coordinates to be mapped
           bound: Float or iterable, bound of interval

--- a/normflows/flows/planar.py
+++ b/normflows/flows/planar.py
@@ -6,17 +6,20 @@ from .base import Flow
 
 
 class Planar(Flow):
-    """
-    Planar flow as introduced in arXiv: 1505.05770
+    """     Planar flow as introduced in [arXiv: 1505.05770](https://arxiv.org/abs/1505.05770)
+    
+    ```
         f(z) = z + u * h(w * z + b)
+    ```
     """
 
     def __init__(self, shape, act="tanh", u=None, w=None, b=None):
-        """
-        Constructor of the planar flow
-        :param shape: shape of the latent variable z
-        :param h: nonlinear function h of the planar flow (see definition of f above)
-        :param u,w,b: optional initialization for parameters
+        """ Constructor of the planar flow
+        
+        Args:
+          shape: shape of the latent variable z
+          h: nonlinear function h of the planar flow (see definition of f above)
+          u,w,b: optional initialization for parameters
         """
         super().__init__()
         lim_w = np.sqrt(2.0 / np.prod(shape))

--- a/normflows/flows/planar.py
+++ b/normflows/flows/planar.py
@@ -6,16 +6,16 @@ from .base import Flow
 
 
 class Planar(Flow):
-    """     Planar flow as introduced in [arXiv: 1505.05770](https://arxiv.org/abs/1505.05770)
-    
+    """Planar flow as introduced in [arXiv: 1505.05770](https://arxiv.org/abs/1505.05770)
+
     ```
         f(z) = z + u * h(w * z + b)
     ```
     """
 
     def __init__(self, shape, act="tanh", u=None, w=None, b=None):
-        """ Constructor of the planar flow
-        
+        """Constructor of the planar flow
+
         Args:
           shape: shape of the latent variable z
           h: nonlinear function h of the planar flow (see definition of f above)

--- a/normflows/flows/radial.py
+++ b/normflows/flows/radial.py
@@ -6,16 +6,19 @@ from .base import Flow
 
 
 class Radial(Flow):
-    """
-    Radial flow as introduced in arXiv: 1505.05770
+    """ Radial flow as introduced in [arXiv: 1505.05770](https://arxiv.org/abs/1505.05770)
+    
+    ```
         f(z) = z + beta * h(alpha, r) * (z - z_0)
+    ```
     """
 
     def __init__(self, shape, z_0=None):
-        """
-        Constructor of the radial flow
-        :param shape: shape of the latent variable z
-        :param z_0: parameter of the radial flow
+        """ Constructor of the radial flow
+        
+        Args:
+          shape: shape of the latent variable z
+          z_0: parameter of the radial flow
         """
         super().__init__()
         self.d_cpu = torch.prod(torch.tensor(shape))

--- a/normflows/flows/radial.py
+++ b/normflows/flows/radial.py
@@ -6,16 +6,16 @@ from .base import Flow
 
 
 class Radial(Flow):
-    """ Radial flow as introduced in [arXiv: 1505.05770](https://arxiv.org/abs/1505.05770)
-    
+    """Radial flow as introduced in [arXiv: 1505.05770](https://arxiv.org/abs/1505.05770)
+
     ```
         f(z) = z + beta * h(alpha, r) * (z - z_0)
     ```
     """
 
     def __init__(self, shape, z_0=None):
-        """ Constructor of the radial flow
-        
+        """Constructor of the radial flow
+
         Args:
           shape: shape of the latent variable z
           z_0: parameter of the radial flow

--- a/normflows/flows/reshape.py
+++ b/normflows/flows/reshape.py
@@ -12,8 +12,8 @@ class Split(Flow):
     """
 
     def __init__(self, mode="channel"):
-        """ Constructor
-        
+        """Constructor
+
         The splitting mode can be:
 
         - channel: Splits first feature dimension, usually channels, into two halfs

--- a/normflows/flows/reshape.py
+++ b/normflows/flows/reshape.py
@@ -12,13 +12,17 @@ class Split(Flow):
     """
 
     def __init__(self, mode="channel"):
-        """
-        Constructor
-        :param mode: Splitting mode, can be
-            channel: Splits first feature dimension, usually channels, into two halfs
-            channel_inv: Same as channel, but with z1 and z2 flipped
-            checkerboard: Splits features using a checkerboard pattern (last feature dimension must be even)
-            checkerboard_inv: Same as checkerboard, but with inverted coloring
+        """ Constructor
+        
+        The splitting mode can be:
+
+        - channel: Splits first feature dimension, usually channels, into two halfs
+        - channel_inv: Same as channel, but with z1 and z2 flipped
+        - checkerboard: Splits features using a checkerboard pattern (last feature dimension must be even)
+        - checkerboard_inv: Same as checkerboard, but with inverted coloring
+
+        Args:
+         mode: splitting mode
         """
         super().__init__()
         self.mode = mode

--- a/normflows/flows/residual.py
+++ b/normflows/flows/residual.py
@@ -12,21 +12,20 @@ from .base import Flow
 class Residual(Flow):
     """
     Invertible residual net block, wrapper to the implementation of Chen et al.,
-    see https://github.com/rtqichen/residual-flows
+    see [sources](https://github.com/rtqichen/residual-flows)
     """
 
     def __init__(
         self, net, n_exact_terms=2, n_samples=1, reduce_memory=True, reverse=True
     ):
-        """
-        Constructor
-        :param net: Neural network, must be Lipschitz continuous with L < 1
-        :param n_exact_terms: Number of terms always included in the power series
-        :param n_samples: Number of samples used to estimate power series
-        :param reduce_memory: Flag, if true Neumann series and precomputations
-        for backward pass in forward pass are done
-        :param reverse: Flag, if true the map f(x) = x + net(x) is applied in
-        the inverse pass, otherwise it is done in forward
+        """ Constructor
+        
+        Args:
+          net: Neural network, must be Lipschitz continuous with L < 1
+          n_exact_terms: Number of terms always included in the power series
+          n_samples: Number of samples used to estimate power series
+          reduce_memory: Flag, if true Neumann series and precomputations, for backward pass in forward pass are done
+          reverse: Flag, if true the map ```f(x) = x + net(x)``` is applied in the inverse pass, otherwise it is done in forward
         """
         super().__init__()
         self.reverse = reverse
@@ -120,7 +119,7 @@ class iResBlock(nn.Module):
         return x
 
     def _logdetgrad(self, x):
-        """Returns g(x) and logdet|d(x+g(x))/dx|."""
+        """Returns g(x) and ```logdet|d(x+g(x))/dx|```"""
 
         with torch.enable_grad():
             if (self.brute_force or not self.training) and (

--- a/normflows/flows/residual.py
+++ b/normflows/flows/residual.py
@@ -18,8 +18,8 @@ class Residual(Flow):
     def __init__(
         self, net, n_exact_terms=2, n_samples=1, reduce_memory=True, reverse=True
     ):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           net: Neural network, must be Lipschitz continuous with L < 1
           n_exact_terms: Number of terms always included in the power series

--- a/normflows/flows/stochastic.py
+++ b/normflows/flows/stochastic.py
@@ -4,13 +4,13 @@ from .base import Flow
 
 
 class MetropolisHastings(Flow):
-    """ Sampling through Metropolis Hastings in Stochastic Normalizing Flow
+    """Sampling through Metropolis Hastings in Stochastic Normalizing Flow
 
     See [arXiv: 2002.06707](https://arxiv.org/abs/2002.06707)
     """
 
     def __init__(self, dist, proposal, steps):
-        """ Constructor
+        """Constructor
 
         Args:
           dist: Distribution to sample from
@@ -50,20 +50,20 @@ class MetropolisHastings(Flow):
 
 
 class HamiltonianMonteCarlo(Flow):
-    """ Flow layer using the HMC proposal in Stochastic Normalising Flows
+    """Flow layer using the HMC proposal in Stochastic Normalising Flows
 
     See [arXiv: 2002.06707](https://arxiv.org/abs/2002.06707)
     """
 
     def __init__(self, target, steps, log_step_size, log_mass, max_abs_grad=None):
-        """ Constructor
+        """Constructor
 
         Args:
           target: The stationary distribution of this Markov transition. Should be logp
           steps: The number of leapfrog steps
           log_step_size: The log step size used in the leapfrog integrator. shape (dim)
           log_mass: The log_mass determining the variance of the momentum samples. shape (dim)
-          max_abs_grad: Maximum absolute value of the gradient of the target distribution's log probability. If set to None then no gradient clipping is applied. Useful for improving numerical stability.        """
+          max_abs_grad: Maximum absolute value of the gradient of the target distribution's log probability. If set to None then no gradient clipping is applied. Useful for improving numerical stability."""
         super().__init__()
         self.target = target
         self.steps = steps

--- a/normflows/flows/stochastic.py
+++ b/normflows/flows/stochastic.py
@@ -4,17 +4,18 @@ from .base import Flow
 
 
 class MetropolisHastings(Flow):
-    """
-    Sampling through Metropolis Hastings in Stochastic Normalizing
-    Flow, see arXiv: 2002.06707
+    """ Sampling through Metropolis Hastings in Stochastic Normalizing Flow
+
+    See [arXiv: 2002.06707](https://arxiv.org/abs/2002.06707)
     """
 
     def __init__(self, dist, proposal, steps):
-        """
-        Constructor
-        :param dist: Distribution to sample from
-        :param proposal: Proposal distribution
-        :param steps: Number of MCMC steps to perform
+        """ Constructor
+
+        Args:
+          dist: Distribution to sample from
+          proposal: Proposal distribution
+          steps: Number of MCMC steps to perform
         """
         super().__init__()
         self.dist = dist
@@ -49,22 +50,20 @@ class MetropolisHastings(Flow):
 
 
 class HamiltonianMonteCarlo(Flow):
-    """
-    Flow layer using the HMC proposal in Stochastic Normalising Flows,
-    see arXiv: 2002.06707
+    """ Flow layer using the HMC proposal in Stochastic Normalising Flows
+
+    See [arXiv: 2002.06707](https://arxiv.org/abs/2002.06707)
     """
 
     def __init__(self, target, steps, log_step_size, log_mass, max_abs_grad=None):
-        """
-        Constructor
-        :param target: The stationary distribution of this Markov transition. Should be logp
-        :param steps: The number of leapfrog steps
-        :param log_step_size: The log step size used in the leapfrog integrator. shape (dim)
-        :param log_mass: The log_mass determining the variance of the momentum samples. shape (dim)
-        :param max_abs_grad: Maximum absolute value of the gradient of the target distribution's
-            log probability. If set to None then no gradient clipping is applied. Useful for
-            improving numerical stability.
-        """
+        """ Constructor
+
+        Args:
+          target: The stationary distribution of this Markov transition. Should be logp
+          steps: The number of leapfrog steps
+          log_step_size: The log step size used in the leapfrog integrator. shape (dim)
+          log_mass: The log_mass determining the variance of the momentum samples. shape (dim)
+          max_abs_grad: Maximum absolute value of the gradient of the target distribution's log probability. If set to None then no gradient clipping is applied. Useful for improving numerical stability.        """
         super().__init__()
         self.target = target
         self.steps = steps

--- a/normflows/nets/cnn.py
+++ b/normflows/nets/cnn.py
@@ -17,17 +17,17 @@ class ConvNet2d(nn.Module):
         actnorm=False,
         weight_std=None,
     ):
-        """
-        Constructor
-        :param channels: List of channels of conv layers, first entry is in_channels
-        :param kernel_size: List of kernel sizes, same for height and width
-        :param leaky: Leaky part of ReLU
-        :param init_zeros: Flag whether last layer shall be initialized with zeros
-        :param scale_output: Flag whether to scale output with a log scale parameter
-        :param logscale_factor: Constant factor to be multiplied to log scaling
-        :param actnorm: Flag whether activation normalization shall be done after
-        each conv layer except output
-        :param weight_std: Fixed std used to initialize every layer
+        """ Constructor
+        
+        Args:
+          channels: List of channels of conv layers, first entry is in_channels
+          kernel_size: List of kernel sizes, same for height and width
+          leaky: Leaky part of ReLU
+          init_zeros: Flag whether last layer shall be initialized with zeros
+          scale_output: Flag whether to scale output with a log scale parameter
+          logscale_factor: Constant factor to be multiplied to log scaling
+          actnorm: Flag whether activation normalization shall be done after each conv layer except output
+          weight_std: Fixed std used to initialize every layer
         """
         super().__init__()
         # Build network

--- a/normflows/nets/cnn.py
+++ b/normflows/nets/cnn.py
@@ -17,8 +17,8 @@ class ConvNet2d(nn.Module):
         actnorm=False,
         weight_std=None,
     ):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           channels: List of channels of conv layers, first entry is in_channels
           kernel_size: List of kernel sizes, same for height and width

--- a/normflows/nets/lipschitz.py
+++ b/normflows/nets/lipschitz.py
@@ -12,9 +12,7 @@ from itertools import repeat
 
 
 class LipschitzMLP(nn.Module):
-    """
-    Fully connected neural net which is Lipschitz continuous
-    with Lipschitz constant L < 1
+    """ Fully connected neural net which is Lipschitz continuou with Lipschitz constant L < 1
     """
 
     def __init__(
@@ -27,15 +25,15 @@ class LipschitzMLP(nn.Module):
     ):
         """
         Constructor
-        :param channels: Integer list with the number of channels of
+          channels: Integer list with the number of channels of
         the layers
-        :param lipschitz_const: Maximum Lipschitz constant of each layer
-        :param max_lipschitz_iter: Maximum number of iterations used to
+          lipschitz_const: Maximum Lipschitz constant of each layer
+          max_lipschitz_iter: Maximum number of iterations used to
         ensure that layers are Lipschitz continuous with L smaller than
         set maximum; if None, tolerance is used
-        :param lipschitz_tolerance: Float, tolerance used to ensure
+          lipschitz_tolerance: Float, tolerance used to ensure
         Lipschitz continuity if max_lipschitz_iter is None, typically 1e-3
-        :param init_zeros: Flag, whether to initialize last layer
+          init_zeros: Flag, whether to initialize last layer
         approximately with zeros
         """
         super().__init__()
@@ -85,19 +83,15 @@ class LipschitzCNN(nn.Module):
         lipschitz_tolerance=None,
         init_zeros=True,
     ):
-        """
-        Constructor
-        :param channels: Integer list with the number of channels of
-        the layers
-        :param kernel_size: Integer list of kernel sizes of the layers
-        :param lipschitz_const: Maximum Lipschitz constant of each layer
-        :param max_lipschitz_iter: Maximum number of iterations used to
-        ensure that layers are Lipschitz continuous with L smaller than
-        set maximum; if None, tolerance is used
-        :param lipschitz_tolerance: Float, tolerance used to ensure
-        Lipschitz continuity if max_lipschitz_iter is None, typically 1e-3
-        :param init_zeros: Flag, whether to initialize last layer
-        approximately with zeros
+        """ Constructor
+
+        Args:
+          channels: Integer list with the number of channels of the layers
+          kernel_size: Integer list of kernel sizes of the layers
+          lipschitz_const: Maximum Lipschitz constant of each layer
+          max_lipschitz_iter: Maximum number of iterations used to ensure that layers are Lipschitz continuous with L smaller than set maximum; if None, tolerance is used
+          lipschitz_tolerance: Float, tolerance used to ensure Lipschitz continuity if max_lipschitz_iter is None, typically 1e-3
+          init_zeros: Flag, whether to initialize last layer approximately with zeros
         """
         super().__init__()
 

--- a/normflows/nets/lipschitz.py
+++ b/normflows/nets/lipschitz.py
@@ -12,8 +12,7 @@ from itertools import repeat
 
 
 class LipschitzMLP(nn.Module):
-    """ Fully connected neural net which is Lipschitz continuou with Lipschitz constant L < 1
-    """
+    """Fully connected neural net which is Lipschitz continuou with Lipschitz constant L < 1"""
 
     def __init__(
         self,
@@ -83,7 +82,7 @@ class LipschitzCNN(nn.Module):
         lipschitz_tolerance=None,
         init_zeros=True,
     ):
-        """ Constructor
+        """Constructor
 
         Args:
           channels: Integer list with the number of channels of the layers

--- a/normflows/nets/made.py
+++ b/normflows/nets/made.py
@@ -84,8 +84,7 @@ class MaskedLinear(nn.Linear):
 class MaskedFeedforwardBlock(nn.Module):
     """A feedforward block based on a masked linear module.
 
-    NOTE: In this implementation, the number of output features is taken to be equal to
-    the number of input features.
+    **NOTE** In this implementation, the number of output features is taken to be equal to the number of input features.
     """
 
     def __init__(

--- a/normflows/nets/mlp.py
+++ b/normflows/nets/mlp.py
@@ -19,19 +19,13 @@ class MLP(nn.Module):
         dropout=None,
     ):
         """
-        :param layers: list of layer sizes from start to end
-        :param leaky: slope of the leaky part of the ReLU,
-        if 0.0, standard ReLU is used
-        :param score_scale: Factor to apply to the scores, i.e. output before
-        output_fn.
-        :param output_fn: String, function to be applied to the output, either
-        None, "sigmoid", "relu", "tanh", or "clampexp"
-        :param output_scale: Rescale outputs if output_fn is specified, i.e.
-        scale * output_fn(out / scale)
-        :param init_zeros: Flag, if true, weights and biases of last layer
-        are initialized with zeros (helpful for deep models, see arXiv 1807.03039)
-        :param dropout: Float, if specified, dropout is done before last layer;
-        if None, no dropout is done
+          layers: list of layer sizes from start to end
+          leaky: slope of the leaky part of the ReLU, if 0.0, standard ReLU is used
+          score_scale: Factor to apply to the scores, i.e. output before output_fn.
+          output_fn: String, function to be applied to the output, either None, "sigmoid", "relu", "tanh", or "clampexp"
+          output_scale: Rescale outputs if output_fn is specified, i.e. ```scale * output_fn(out / scale)```
+          init_zeros: Flag, if true, weights and biases of last layer are initialized with zeros (helpful for deep models, see [arXiv 1807.03039](https://arxiv.org/abs/1807.03039))
+          dropout: Float, if specified, dropout is done before last layer; if None, no dropout is done
         """
         super().__init__()
         net = nn.ModuleList([])

--- a/normflows/nets/mlp.py
+++ b/normflows/nets/mlp.py
@@ -19,13 +19,13 @@ class MLP(nn.Module):
         dropout=None,
     ):
         """
-          layers: list of layer sizes from start to end
-          leaky: slope of the leaky part of the ReLU, if 0.0, standard ReLU is used
-          score_scale: Factor to apply to the scores, i.e. output before output_fn.
-          output_fn: String, function to be applied to the output, either None, "sigmoid", "relu", "tanh", or "clampexp"
-          output_scale: Rescale outputs if output_fn is specified, i.e. ```scale * output_fn(out / scale)```
-          init_zeros: Flag, if true, weights and biases of last layer are initialized with zeros (helpful for deep models, see [arXiv 1807.03039](https://arxiv.org/abs/1807.03039))
-          dropout: Float, if specified, dropout is done before last layer; if None, no dropout is done
+        layers: list of layer sizes from start to end
+        leaky: slope of the leaky part of the ReLU, if 0.0, standard ReLU is used
+        score_scale: Factor to apply to the scores, i.e. output before output_fn.
+        output_fn: String, function to be applied to the output, either None, "sigmoid", "relu", "tanh", or "clampexp"
+        output_scale: Rescale outputs if output_fn is specified, i.e. ```scale * output_fn(out / scale)```
+        init_zeros: Flag, if true, weights and biases of last layer are initialized with zeros (helpful for deep models, see [arXiv 1807.03039](https://arxiv.org/abs/1807.03039))
+        dropout: Float, if specified, dropout is done before last layer; if None, no dropout is done
         """
         super().__init__()
         net = nn.ModuleList([])

--- a/normflows/sampling/hais.py
+++ b/normflows/sampling/hais.py
@@ -35,8 +35,8 @@ class HAIS:
             ]
 
     def sample(self, num_samples):
-        """ Run HAIS to draw samples from the target with appropriate weights.
-        
+        """Run HAIS to draw samples from the target with appropriate weights.
+
         Args:
           num_samples: The number of samples to draw.a
         """

--- a/normflows/sampling/hais.py
+++ b/normflows/sampling/hais.py
@@ -12,17 +12,13 @@ class HAIS:
 
     def __init__(self, betas, prior, target, num_leapfrog, step_size, log_mass):
         """
-        :param betas: Annealing schedule, the jth target is f_j(x) =
-            f_0(x)^{\beta_j} f_n(x)^{1-\beta_j} where the target is proportional
-            to f_0 and the prior is proportional to f_n. The number of
-            intermediate steps is infered from the shape of betas.
-            Should be of the form 1 = \beta_0 > \beta_1 > ... > \beta_n = 0
-        :param prior: The prior distribution to start the HAIS chain.
-        :param target: The target distribution from which we would like to draw
-            weighted samples.
-        :param num_leapfrog: Number of leapfrog steps in the HMC transitions.
-        :param step_size: step_size to use for HMC transitions.
-        :param log_mass: log_mass to use for HMC transitions.
+        Args:
+          betas: Annealing schedule, the jth target is ```f_j(x) = f_0(x)^{\beta_j} f_n(x)^{1-\beta_j}``` where the target is proportional to f_0 and the prior is proportional to f_n. The number of intermediate steps is infered from the shape of betas. Should be of the form 1 = \beta_0 > \beta_1 > ... > \beta_n = 0
+          prior: The prior distribution to start the HAIS chain.
+          target: The target distribution from which we would like to draw weighted samples.
+          num_leapfrog: Number of leapfrog steps in the HMC transitions.
+          step_size: step_size to use for HMC transitions.
+          log_mass: log_mass to use for HMC transitions.
         """
         self.prior = prior
         self.target = target
@@ -39,9 +35,10 @@ class HAIS:
             ]
 
     def sample(self, num_samples):
-        """
-        Run HAIS to draw samples from the target with appropriate weights.
-        :param num_samples: The number of samples to draw.
+        """ Run HAIS to draw samples from the target with appropriate weights.
+        
+        Args:
+          num_samples: The number of samples to draw.a
         """
         samples, log_weights = self.prior.forward(num_samples)
         log_weights = -log_weights

--- a/normflows/transforms.py
+++ b/normflows/transforms.py
@@ -6,15 +6,19 @@ from . import flows
 
 
 class Logit(flows.Flow):
-    """
-    Logit mapping of image tensor, see RealNVP paper
+    """     Logit mapping of image tensor, see RealNVP paper
+
+    ```
     logit(alpha + (1 - alpha) * x) where logit(x) = log(x / (1 - x))
+    ```
+
     """
 
     def __init__(self, alpha=0.05):
-        """
-        Constructor
-        :param alpha: Alpha parameter, see above
+        """ Constructor
+
+        Args:
+          alpha: Alpha parameter, see above
         """
         super().__init__()
         self.alpha = alpha
@@ -44,15 +48,17 @@ class Logit(flows.Flow):
 
 
 class Shift(flows.Flow):
-    """
-    Shift data by a fixed constant, default is -0.5 to shift data from
+    """ Shift data by a fixed constant
+    
+    Default is -0.5 to shift data from
     interval [0, 1] to [-0.5, 0.5]
     """
 
     def __init__(self, shift=-0.5):
-        """
-        Constructor
-        :param shift: Shift to apply to the data
+        """ Constructor
+        
+        Args:
+          shift: Shift to apply to the data
         """
         super().__init__()
         self.shift = shift

--- a/normflows/transforms.py
+++ b/normflows/transforms.py
@@ -6,7 +6,7 @@ from . import flows
 
 
 class Logit(flows.Flow):
-    """     Logit mapping of image tensor, see RealNVP paper
+    """Logit mapping of image tensor, see RealNVP paper
 
     ```
     logit(alpha + (1 - alpha) * x) where logit(x) = log(x / (1 - x))
@@ -15,7 +15,7 @@ class Logit(flows.Flow):
     """
 
     def __init__(self, alpha=0.05):
-        """ Constructor
+        """Constructor
 
         Args:
           alpha: Alpha parameter, see above
@@ -48,15 +48,15 @@ class Logit(flows.Flow):
 
 
 class Shift(flows.Flow):
-    """ Shift data by a fixed constant
-    
+    """Shift data by a fixed constant
+
     Default is -0.5 to shift data from
     interval [0, 1] to [-0.5, 0.5]
     """
 
     def __init__(self, shift=-0.5):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           shift: Shift to apply to the data
         """

--- a/normflows/utils/eval.py
+++ b/normflows/utils/eval.py
@@ -3,14 +3,17 @@ import numpy as np
 
 
 def bitsPerDim(model, x, y=None, trans="logit", trans_param=[0.05]):
-    """
-    Computes the bits per dim for a batch of data
-    :param model: Model to compute bits per dim for
-    :param x: Batch of data
-    :param y: Class labels for batch of data if base distribution is class conditional
-    :param trans: Transformation to be applied to images during training
-    :param trans_param: List of parameters of the transformation
-    :return: Bits per dim for data batch under model
+    """ Computes the bits per dim for a batch of data
+
+    Args:
+      model: Model to compute bits per dim for
+      x: Batch of data
+      y: Class labels for batch of data if base distribution is class conditional
+      trans: Transformation to be applied to images during training
+      trans_param: List of parameters of the transformation
+
+    Returns:
+      Bits per dim for data batch under model
     """
     dims = torch.prod(torch.tensor(x.size()[1:]))
     if trans == "logit":
@@ -34,14 +37,17 @@ def bitsPerDim(model, x, y=None, trans="logit", trans_param=[0.05]):
 def bitsPerDimDataset(
     model, data_loader, class_cond=True, trans="logit", trans_param=[0.05]
 ):
-    """
-    Computes average bits per dim for an entire dataset given by a data loader
-    :param model: Model to compute bits per dim for
-    :param data_loader: Data loader of dataset
-    :param class_cond: Flag indicating whether model is class_conditional
-    :param trans: Transformation to be applied to images during training
-    :param trans_param: List of parameters of the transformation
-    :return: Average bits per dim for dataset
+    """ Computes average bits per dim for an entire dataset given by a data loader
+    
+    Args:
+      model: Model to compute bits per dim for
+      data_loader: Data loader of dataset
+      class_cond: Flag indicating whether model is class_conditional
+      trans: Transformation to be applied to images during training
+      trans_param: List of parameters of the transformation
+
+    Returns:
+      Average bits per dim for dataset
     """
     n = 0
     b_cum = 0

--- a/normflows/utils/eval.py
+++ b/normflows/utils/eval.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 def bitsPerDim(model, x, y=None, trans="logit", trans_param=[0.05]):
-    """ Computes the bits per dim for a batch of data
+    """Computes the bits per dim for a batch of data
 
     Args:
       model: Model to compute bits per dim for
@@ -37,8 +37,8 @@ def bitsPerDim(model, x, y=None, trans="logit", trans_param=[0.05]):
 def bitsPerDimDataset(
     model, data_loader, class_cond=True, trans="logit", trans_param=[0.05]
 ):
-    """ Computes average bits per dim for an entire dataset given by a data loader
-    
+    """Computes average bits per dim for an entire dataset given by a data loader
+
     Args:
       model: Model to compute bits per dim for
       data_loader: Data loader of dataset

--- a/normflows/utils/masks.py
+++ b/normflows/utils/masks.py
@@ -2,8 +2,8 @@ import torch
 
 
 def create_alternating_binary_mask(features, even=True):
-    """ Creates a binary mask of a given dimension which alternates its masking.
-    
+    """Creates a binary mask of a given dimension which alternates its masking.
+
     Args:
       features: Dimension of mask.
       even: If True, even values are assigned 1s, odd 0s. If False, vice versa.
@@ -18,8 +18,8 @@ def create_alternating_binary_mask(features, even=True):
 
 
 def create_mid_split_binary_mask(features):
-    """ Creates a binary mask of a given dimension which splits its masking at the midpoint.
-    
+    """Creates a binary mask of a given dimension which splits its masking at the midpoint.
+
     Args:
       features: Dimension of mask.
 
@@ -33,7 +33,7 @@ def create_mid_split_binary_mask(features):
 
 
 def create_random_binary_mask(features, seed=None):
-    """ Creates a random binary mask of a given dimension with half of its entries randomly set to 1s.
+    """Creates a random binary mask of a given dimension with half of its entries randomly set to 1s.
 
     Args:
       features: Dimension of mask.

--- a/normflows/utils/masks.py
+++ b/normflows/utils/masks.py
@@ -2,12 +2,14 @@ import torch
 
 
 def create_alternating_binary_mask(features, even=True):
-    """
-    Creates a binary mask of a given dimension which alternates its masking.
+    """ Creates a binary mask of a given dimension which alternates its masking.
+    
+    Args:
+      features: Dimension of mask.
+      even: If True, even values are assigned 1s, odd 0s. If False, vice versa.
 
-    :param features: Dimension of mask.
-    :param even: If True, even values are assigned 1s, odd 0s. If False, vice versa.
-    :return: Alternating binary mask of type torch.Tensor.
+    Returns:
+      Alternating binary mask of type torch.Tensor.
     """
     mask = torch.zeros(features).byte()
     start = 0 if even else 1
@@ -16,11 +18,13 @@ def create_alternating_binary_mask(features, even=True):
 
 
 def create_mid_split_binary_mask(features):
-    """
-    Creates a binary mask of a given dimension which splits its masking at the midpoint.
+    """ Creates a binary mask of a given dimension which splits its masking at the midpoint.
+    
+    Args:
+      features: Dimension of mask.
 
-    :param features: Dimension of mask.
-    :return: Binary mask split at midpoint of type torch.Tensor
+    Returns:
+      Binary mask split at midpoint of type torch.Tensor
     """
     mask = torch.zeros(features).byte()
     midpoint = features // 2 if features % 2 == 0 else features // 2 + 1
@@ -29,13 +33,14 @@ def create_mid_split_binary_mask(features):
 
 
 def create_random_binary_mask(features, seed=None):
-    """
-    Creates a random binary mask of a given dimension with half of its entries
-    randomly set to 1s.
+    """ Creates a random binary mask of a given dimension with half of its entries randomly set to 1s.
 
-    :param features: Dimension of mask.
-    :param seed: Seed to be used
-    :return: Binary mask with half of its entries set to 1s, of type torch.Tensor.
+    Args:
+      features: Dimension of mask.
+      seed: Seed to be used
+
+    Returns:
+      Binary mask with half of its entries set to 1s, of type torch.Tensor.
     """
     mask = torch.zeros(features).byte()
     weights = torch.ones(features).float()

--- a/normflows/utils/nn.py
+++ b/normflows/utils/nn.py
@@ -10,9 +10,10 @@ class ConstScaleLayer(nn.Module):
     """
 
     def __init__(self, scale=1.0):
-        """
-        Constructor
-        :param scale: Scale to apply to features
+        """ Constructor
+        
+        Args:
+          scale: Scale to apply to features
         """
         super().__init__()
         self.scale_cpu = torch.tensor(scale)
@@ -28,10 +29,11 @@ class ActNorm(nn.Module):
     """
 
     def __init__(self, shape, logscale_factor=None):
-        """
-        Constructor
-        :param shape: Same as shape in flows.ActNorm
-        :param logscale_factor: Same as shape in flows.ActNorm
+        """ Constructor
+        
+        Args:
+          shape: Same as shape in flows.ActNorm
+          logscale_factor: Same as shape in flows.ActNorm
         """
         super().__init__()
         self.actNorm = flows.ActNorm(shape, logscale_factor=logscale_factor)
@@ -47,9 +49,10 @@ class ClampExp(nn.Module):
     """
 
     def __init__(self):
-        """
-        Constructor
-        :param lam: Lambda parameter
+        """ Constructor
+        
+        Args:
+          lam: Lambda parameter
         """
         super(ClampExp, self).__init__()
 
@@ -64,16 +67,14 @@ class PeriodicFeatures(nn.Module):
     """
 
     def __init__(self, ndim, ind, scale=1.0, bias=False, activation=None):
-        """
-        Constructor
-        :param ndim: Int, number of dimensions
-        :param ind: Iterable, indices of input elements to convert to
-        periodic features
-        :param scale: Scalar or iterable, used to scale inputs before
-        converting them to periodic features
-        :param bias: Flag, whether to add a bias
-        :param activation: Function or None, activation function to be
-        applied
+        """ Constructor
+        
+        Args:
+          ndim (int): number of dimensions
+          ind (iterable): indices of input elements to convert to periodic features
+          scale: Scalar or iterable, used to scale inputs before converting them to periodic features
+          bias: Flag, whether to add a bias
+          activation: Function or None, activation function to be applied
         """
         super(PeriodicFeatures, self).__init__()
 

--- a/normflows/utils/nn.py
+++ b/normflows/utils/nn.py
@@ -10,8 +10,8 @@ class ConstScaleLayer(nn.Module):
     """
 
     def __init__(self, scale=1.0):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           scale: Scale to apply to features
         """
@@ -29,8 +29,8 @@ class ActNorm(nn.Module):
     """
 
     def __init__(self, shape, logscale_factor=None):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           shape: Same as shape in flows.ActNorm
           logscale_factor: Same as shape in flows.ActNorm
@@ -49,8 +49,8 @@ class ClampExp(nn.Module):
     """
 
     def __init__(self):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           lam: Lambda parameter
         """
@@ -67,8 +67,8 @@ class PeriodicFeatures(nn.Module):
     """
 
     def __init__(self, ndim, ind, scale=1.0, bias=False, activation=None):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           ndim (int): number of dimensions
           ind (iterable): indices of input elements to convert to periodic features

--- a/normflows/utils/optim.py
+++ b/normflows/utils/optim.py
@@ -2,8 +2,8 @@ from ..nets.lipschitz import InducedNormLinear, InducedNormConv2d
 
 
 def set_requires_grad(module, flag):
-    """ Sets requires_grad flag of all parameters of a torch.nn.module
-    
+    """Sets requires_grad flag of all parameters of a torch.nn.module
+
     Args:
       module: torch.nn.module
       flag: Flag to set requires_grad to
@@ -14,7 +14,7 @@ def set_requires_grad(module, flag):
 
 
 def clear_grad(model):
-    """ Set gradients of model parameter to None as this speeds up training,
+    """Set gradients of model parameter to None as this speeds up training,
 
     See [youtube](https://www.youtube.com/watch?v=9mS1fIYj1So)
 

--- a/normflows/utils/optim.py
+++ b/normflows/utils/optim.py
@@ -2,10 +2,11 @@ from ..nets.lipschitz import InducedNormLinear, InducedNormConv2d
 
 
 def set_requires_grad(module, flag):
-    """
-    Sets requires_grad flag of all parameters of a torch.nn.module
-    :param module: torch.nn.module
-    :param flag: Flag to set requires_grad to
+    """ Sets requires_grad flag of all parameters of a torch.nn.module
+    
+    Args:
+      module: torch.nn.module
+      flag: Flag to set requires_grad to
     """
 
     for param in module.parameters():
@@ -13,10 +14,12 @@ def set_requires_grad(module, flag):
 
 
 def clear_grad(model):
-    """
-    Set gradients of model parameter to None as this speeds up training,
-    see https://www.youtube.com/watch?v=9mS1fIYj1So
-    :param model: Model to clear gradients of
+    """ Set gradients of model parameter to None as this speeds up training,
+
+    See [youtube](https://www.youtube.com/watch?v=9mS1fIYj1So)
+
+    Args:
+      model: Model to clear gradients of
     """
     for param in model.parameters():
         param.grad = None

--- a/normflows/utils/preprocessing.py
+++ b/normflows/utils/preprocessing.py
@@ -2,16 +2,16 @@ import torch
 
 
 class Logit:
-    """ Transform for dataloader
-    
+    """Transform for dataloader
+
     ```
     logit(alpha + (1 - alpha) * x) where logit(x) = log(x / (1 - x))
     ```
     """
 
     def __init__(self, alpha=0):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           alpha: see above
         """
@@ -26,12 +26,11 @@ class Logit:
 
 
 class Jitter:
-    """ Transform for dataloader, adds uniform jitter noise to data
-    """
+    """Transform for dataloader, adds uniform jitter noise to data"""
 
     def __init__(self, scale=1.0 / 256):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           scale: Scaling factor for noise
         """
@@ -44,12 +43,11 @@ class Jitter:
 
 
 class Scale:
-    """ Transform for dataloader, adds uniform jitter noise to data
-    """
+    """Transform for dataloader, adds uniform jitter noise to data"""
 
     def __init__(self, scale=255.0 / 256.0):
-        """ Constructor
-        
+        """Constructor
+
         Args:
           scale: Scaling factor for noise
         """

--- a/normflows/utils/preprocessing.py
+++ b/normflows/utils/preprocessing.py
@@ -2,15 +2,18 @@ import torch
 
 
 class Logit:
-    """
-    Transform for dataloader
+    """ Transform for dataloader
+    
+    ```
     logit(alpha + (1 - alpha) * x) where logit(x) = log(x / (1 - x))
+    ```
     """
 
     def __init__(self, alpha=0):
-        """
-        Constructor
-        :param alpha: see above
+        """ Constructor
+        
+        Args:
+          alpha: see above
         """
         self.alpha = alpha
 
@@ -23,15 +26,14 @@ class Logit:
 
 
 class Jitter:
-    """
-    Transform for dataloader
-    Adds uniform jitter noise to data
+    """ Transform for dataloader, adds uniform jitter noise to data
     """
 
     def __init__(self, scale=1.0 / 256):
-        """
-        Constructor
-        :param scale: Scaling factor for noise
+        """ Constructor
+        
+        Args:
+          scale: Scaling factor for noise
         """
         self.scale = scale
 
@@ -42,15 +44,14 @@ class Jitter:
 
 
 class Scale:
-    """
-    Transform for dataloader
-    Adds uniform jitter noise to data
+    """ Transform for dataloader, adds uniform jitter noise to data
     """
 
     def __init__(self, scale=255.0 / 256.0):
-        """
-        Constructor
-        :param scale: Scaling factor for noise
+        """ Constructor
+        
+        Args:
+          scale: Scaling factor for noise
         """
         self.scale = scale
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author="Vincent Stimper",
     author_email="vincent.stimper@tuebingen.mpg.de",
     install_requires=install_requires,
-    extra_requires={
-        "docs": ["mkdocs","mkdocstrings[python]","mkdocs-material","mkdocs-jupyter"]
+    extras_require={
+        "docs": ["mkdocs","mkdocstrings[python]","mkdocs-jupyter"]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,7 @@ setup(
     author="Vincent Stimper",
     author_email="vincent.stimper@tuebingen.mpg.de",
     install_requires=install_requires,
+    extra_requires={
+        "docs": ["mkdocs","mkdocstrings[python]","mkdocs-material","mkdocs-jupyter"]
+    },
 )


### PR DESCRIPTION
Added mkdocs structure, and refactored the docstrings (and applied black)

to install the dependencies for documentation building:

```
pip install -e ".[docs]"
```

To see the doc:

```
mkdocs serve
```

This starts a live server. Modifications of the documentation are rendered live (excluded the modications to docstrings)

To build the docs:

```
mkdocs build
```
this will create the site folder (including index.html)

To expend the docs:

Markdown files can be added in the docs folder, then the "nav" section of the mkdocs.yml file has to be updated, e.g.

```
nav:
  - about: index.md
  - API: references.md
  - my other page: mymarkdown.md
```

- good to know: markdown can be used in the docstrings.
- apparently, deploying the documentation online on github after built is as simple as calling ```mkdocs gh-deploy``` (I did not try it yet)

I still need to do:

- continuous build on github (documentation is rebuilt and deployed at each merge into master)
- a correction pass on the docstrings (I updated them, but did not check them one by one yet)
- the layout is not so nice (especially for the API), needs to be improved
- apparently mkdocs allows to display jupyter notebooks, I need to dig