### PR TITLE
Fix deprecation warning

### DIFF
--- a/normflows/flows/mixing.py
+++ b/normflows/flows/mixing.py
@@ -434,11 +434,11 @@ class _LULinear(_Linear):
         """
         lower, upper = self._create_lower_upper()
         outputs = inputs - self.bias
-        outputs, _ = torch.triangular_solve(
-            outputs.t(), lower, upper=False, unitriangular=True
+        outputs = torch.linalg.solve_triangular(
+            lower, outputs.t(), upper=False, unitriangular=True
         )
-        outputs, _ = torch.triangular_solve(
-            outputs, upper, upper=True, unitriangular=False
+        outputs = torch.linalg.solve_triangular(
+            upper, outputs, upper=True, unitriangular=False
         )
         outputs = outputs.t()
 


### PR DESCRIPTION
Fixes the deprecation warning documented in https://github.com/VincentStimper/normalizing-flows/issues/12.

---

**Sanity check:** Running this before the change:

```python
import normflows as nf
import torch

torch.manual_seed(42)

flow = nf.NormalizingFlow(
    nf.distributions.DiagGaussian(1, trainable=False),
    [
        nf.flows.AutoregressiveRationalQuadraticSpline(1, 1, 1),
        nf.flows.LULinearPermute(1)
    ]
)

with torch.no_grad():
    samples_flow, _ = flow.sample(4)

print(samples_flow)
```

gives:

```
tensor([[0.4528],
        [0.6410],
        [0.5200],
        [0.5567]])
```

After the change, the output stays the same.