### PR TITLE
added jupyter notebooks to the html documentation

### DIFF
--- a/docs/notebooks/augmented_flow.ipynb
+++ b/docs/notebooks/augmented_flow.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/augmented_flow.ipynb

--- a/docs/notebooks/change_base_distribution.ipynb
+++ b/docs/notebooks/change_base_distribution.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/change_base_distribution.ipynb

--- a/docs/notebooks/circular_nsf.ipynb
+++ b/docs/notebooks/circular_nsf.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/circular_nsf.ipynb

--- a/docs/notebooks/comparison_plan_rad_aff.ipynb
+++ b/docs/notebooks/comparison_plan_rad_aff.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/comparison_plan_rad_aff.ipynb

--- a/docs/notebooks/glow.ipynb
+++ b/docs/notebooks/glow.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/glow.ipynb

--- a/docs/notebooks/glow_colab.ipynb
+++ b/docs/notebooks/glow_colab.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/glow_colab.ipynb

--- a/docs/notebooks/image.ipynb
+++ b/docs/notebooks/image.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/image.ipynb

--- a/docs/notebooks/neural_spline_flow.ipynb
+++ b/docs/notebooks/neural_spline_flow.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/neural_spline_flow.ipynb

--- a/docs/notebooks/paper_example_nsf.ipynb
+++ b/docs/notebooks/paper_example_nsf.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/paper_example_nsf.ipynb

--- a/docs/notebooks/paper_example_nsf_colab.ipynb
+++ b/docs/notebooks/paper_example_nsf_colab.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/paper_example_nsf_colab.ipynb

--- a/docs/notebooks/planar.ipynb
+++ b/docs/notebooks/planar.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/planar.ipynb

--- a/docs/notebooks/real_nvp.ipynb
+++ b/docs/notebooks/real_nvp.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/real_nvp.ipynb

--- a/docs/notebooks/real_nvp_ipynb
+++ b/docs/notebooks/real_nvp_ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/real_nvp_colab.ipynb

--- a/docs/notebooks/residual.ipynb
+++ b/docs/notebooks/residual.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/residual.ipynb

--- a/docs/notebooks/vae.ipynb
+++ b/docs/notebooks/vae.ipynb
@@ -1,0 +1,1 @@
+/home/vberenz/Workspaces/normalizing-flows/examples/vae.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_url: https://github.com/VincentStimper/normalizing-flows
 plugins:
   - search
   - autorefs
+  - mkdocs-jupyter
   - mkdocstrings:
       handlers:
         python:
@@ -12,5 +13,18 @@ plugins:
             show_submodules: true
 
 nav:
-  - about: index.md
+  - About: index.md
   - API: references.md
+  - Examples:
+    - augmented_flow: notebooks/augmented_flow.ipynb
+    - change_base_distribution: notebooks/change_base_distribution.ipynb
+    - circular_nsf: notebooks/circular_nsf.ipynb
+    - comparison_plan_rad_aff: notebooks/comparison_plan_rad_aff.ipynb
+    - glow: notebooks/glow.ipynb
+    - image: notebooks/image.ipynb
+    - neural_spline_flow: notebooks/neural_spline_flow.ipynb
+    - paper_example_nsf: notebooks/paper_example_nsf.ipynb
+    - planar: notebooks/planar.ipynb
+    - real_nvp: notebooks/real_nvp.ipynb
+    - residual: notebooks/residual.ipynb
+    - vae: notebooks/vae.ipynb


### PR DESCRIPTION
Related issue: https://github.com/VincentStimper/normalizing-flows/issues/35

Updated the file mkdocs.yml so that jupyter notebooks are displayed in the html documentation.
The "ipynb" files were not moved from the examples folder, but symbolics links in the docs folder were created.

mkdocs built successfully the html files locally on my desktop.