### PR TITLE
feat: check types in splines to allow amp

### DIFF
--- a/normflows/utils/splines.py
+++ b/normflows/utils/splines.py
@@ -87,8 +87,12 @@ def unconstrained_rational_quadratic_spline(
         min_bin_height=min_bin_height,
         min_derivative=min_derivative,
     )
-    outputs[inside_interval_mask] = outputs_masked.to(outputs.dtype)
-    logabsdet[inside_interval_mask] = logabsdet_masked.to(logabsdet.dtype)
+    if outputs.dtype == outputs_masked.dtype and logabsdet.dtype == logabsdet_masked.dtype:
+        outputs[inside_interval_mask] = outputs_masked
+        logabsdet[inside_interval_mask] = logabsdet_masked
+    else:
+        outputs[inside_interval_mask] = outputs_masked.to(outputs.dtype)
+        logabsdet[inside_interval_mask] = logabsdet_masked.to(logabsdet.dtype)
 
     return outputs, logabsdet
 

--- a/normflows/utils/splines.py
+++ b/normflows/utils/splines.py
@@ -71,8 +71,8 @@ def unconstrained_rational_quadratic_spline(
         top = tail_bound
 
     (
-        outputs[inside_interval_mask],
-        logabsdet[inside_interval_mask],
+        outputs_masked,
+        logabsdet_masked
     ) = rational_quadratic_spline(
         inputs=inputs[inside_interval_mask],
         unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
@@ -87,6 +87,8 @@ def unconstrained_rational_quadratic_spline(
         min_bin_height=min_bin_height,
         min_derivative=min_derivative,
     )
+    outputs[inside_interval_mask] = outputs_masked.to(outputs.dtype)
+    logabsdet[inside_interval_mask] = logabsdet_masked.to(logabsdet.dtype)
 
     return outputs, logabsdet
 


### PR DESCRIPTION
* Check types and cast them if necessary in spline function so that splines and, hence, neural spline flows can be trained with automatic mixed precision (amp)