### PR TITLE
Updating deprecated torch.trtrs

### DIFF
--- a/normflows/flows/mixing.py
+++ b/normflows/flows/mixing.py
@@ -505,9 +505,9 @@ class _LULinear(_Linear):
         """
         lower, upper = self._create_lower_upper()
         identity = torch.eye(self.features, self.features)
-        lower_inverse, _ = torch.trtrs(identity, lower, upper=False, unitriangular=True)
-        weight_inverse, _ = torch.trtrs(
-            lower_inverse, upper, upper=True, unitriangular=False
+        lower_inverse = torch.linalg.solve_triangular(lower, identity, upper=False, unitriangular=True)
+        weight_inverse = torch.linalg.solve_triangular(
+            upper, lower_inverse, upper=True, unitriangular=False
         )
         return weight_inverse
 


### PR DESCRIPTION
## Issue
The function `torch.trtrs` is an alias for the now deprecated `torch.triangular_solve`.
https://pytorch.org/docs/stable/generated/torch.triangular_solve.html

The alias itself has been completely removed in later pytorch releases (>2.1).

`normflows` calls this unsupported alias which results in an attribute error when running the `_LULiner` layers with `use_cache=True`.

https://github.com/VincentStimper/normalizing-flows/blob/1d9707e2f17449107c477801cbb7ce30d9ddb001/normflows/flows/mixing.py#L508

## Solution
Replace the unsupported alias with the recommended function `torch.linalg.solve_triangular` (already used elsewhere in the project). 
https://pytorch.org/docs/stable/generated/torch.linalg.solve_triangular.html

This requires swapping the order of the inputs while also removing extra (and ignored) returned copies. 

