### PR TITLE
no mkdocs workflow on pull request

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
   workflow_dispatch:
 jobs:
   deploy:


### PR DESCRIPTION
Currently, the documentation is updated on every pull request, even before the pull request is accepted.
Removing the execution of the workflow upon pull request.
The workflow should nevertheless be executed upon acceptance of the pull request.  