### PR TITLE
BUG Fix multiscale flow to not require class conditional

### DIFF
--- a/normflows/core.py
+++ b/normflows/core.py
@@ -585,12 +585,12 @@ class MultiscaleFlow(nn.Module):
             self.reset_temperature()
         return z, log_q
 
-    def log_prob(self, x, y):
+    def log_prob(self, x, y=None):
         """Get log probability for batch
 
         Args:
           x: Batch
-          y: Classes of x
+          y: Classes of x. Must be passed in if `class_cond` is True.
 
         Returns:
           log probability


### PR DESCRIPTION
The multi scale Flow has a required parameter in `log_prob` for `y`, which is not required if `class_cond=False`.