### PR TITLE
Support for ONNX export

### DIFF
--- a/examples/onnx_export.ipynb
+++ b/examples/onnx_export.ipynb
@@ -1,0 +1,315 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wUYE8Wz2ojXF"
+      },
+      "source": [
+        "# ONNX export example for Neural Spline Flow"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "niwtdQWHojXF"
+      },
+      "outputs": [],
+      "source": [
+        "# Import required packages\n",
+        "import torch\n",
+        "import numpy as np\n",
+        "import normflows as nf\n",
+        "\n",
+        "from sklearn.datasets import make_moons\n",
+        "\n",
+        "from matplotlib import pyplot as plt\n",
+        "\n",
+        "from tqdm import tqdm\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Ocyo6e9SojXG",
+        "scrolled": false
+      },
+      "outputs": [],
+      "source": [
+        "# Set up model\n",
+        "\n",
+        "# Define flows\n",
+        "K = 16\n",
+        "torch.manual_seed(0)\n",
+        "\n",
+        "latent_size = 2\n",
+        "hidden_units = 128\n",
+        "hidden_layers = 2\n",
+        "\n",
+        "flows = []\n",
+        "for i in range(K):\n",
+        "    flows += [nf.flows.AutoregressiveRationalQuadraticSpline(latent_size, hidden_layers, hidden_units)]\n",
+        "    flows += [nf.flows.LULinearPermute(latent_size)]\n",
+        "\n",
+        "# Set base distribuiton\n",
+        "q0 = nf.distributions.DiagGaussian(2, trainable=False)\n",
+        "\n",
+        "# Construct flow model\n",
+        "nfm = nf.NormalizingFlow(q0=q0, flows=flows)\n",
+        "\n",
+        "# Move model on GPU if available\n",
+        "enable_cuda = True\n",
+        "device = torch.device('cuda' if torch.cuda.is_available() and enable_cuda else 'cpu')\n",
+        "nfm = nfm.to(device)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "gfaPXsACojXG",
+        "outputId": "44658aca-aff5-41c5-a8e2-651b8abaf84a",
+        "scrolled": false
+      },
+      "outputs": [],
+      "source": [
+        "# Plot target distribution\n",
+        "x_np, _ = make_moons(2 ** 20, noise=0.1)\n",
+        "plt.figure(figsize=(15, 15))\n",
+        "plt.hist2d(x_np[:, 0], x_np[:, 1], bins=200)\n",
+        "plt.show()\n",
+        "\n",
+        "# Plot initial flow distribution\n",
+        "grid_size = 100\n",
+        "xx, yy = torch.meshgrid(torch.linspace(-1.5, 2.5, grid_size), torch.linspace(-2, 2, grid_size))\n",
+        "zz = torch.cat([xx.unsqueeze(2), yy.unsqueeze(2)], 2).view(-1, 2)\n",
+        "zz = zz.to(device)\n",
+        "\n",
+        "nfm.eval()\n",
+        "log_prob = nfm.log_prob(zz).to('cpu').view(*xx.shape)\n",
+        "nfm.train()\n",
+        "prob = torch.exp(log_prob)\n",
+        "prob[torch.isnan(prob)] = 0\n",
+        "\n",
+        "plt.figure(figsize=(15, 15))\n",
+        "plt.pcolormesh(xx, yy, prob.data.numpy())\n",
+        "plt.gca().set_aspect('equal', 'box')\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "2ratRmYAojXG",
+        "outputId": "8359d715-53f2-4cef-fd3e-5fa6d74c80ed",
+        "scrolled": false
+      },
+      "outputs": [],
+      "source": [
+        "# Train model\n",
+        "max_iter = 10\n",
+        "num_samples = 2 ** 9\n",
+        "show_iter = 5\n",
+        "\n",
+        "\n",
+        "loss_hist = np.array([])\n",
+        "\n",
+        "optimizer = torch.optim.Adam(nfm.parameters(), lr=1e-3, weight_decay=1e-5)\n",
+        "for it in tqdm(range(max_iter)):\n",
+        "    optimizer.zero_grad()\n",
+        "\n",
+        "    # Get training samples\n",
+        "    x_np, _ = make_moons(num_samples, noise=0.1)\n",
+        "    x = torch.tensor(x_np).float().to(device)\n",
+        "\n",
+        "    # Compute loss\n",
+        "    loss = nfm.forward_kld(x)\n",
+        "\n",
+        "    # Do backprop and optimizer step\n",
+        "    if ~(torch.isnan(loss) | torch.isinf(loss)):\n",
+        "        loss.backward()\n",
+        "        optimizer.step()\n",
+        "\n",
+        "    # Log loss\n",
+        "    loss_hist = np.append(loss_hist, loss.to('cpu').data.numpy())\n",
+        "\n",
+        "    # Plot learned distribution\n",
+        "    if (it + 1) % show_iter == 0:\n",
+        "        nfm.eval()\n",
+        "        log_prob = nfm.log_prob(zz)\n",
+        "        nfm.train()\n",
+        "        prob = torch.exp(log_prob.to('cpu').view(*xx.shape))\n",
+        "        prob[torch.isnan(prob)] = 0\n",
+        "\n",
+        "        plt.figure(figsize=(15, 15))\n",
+        "        plt.pcolormesh(xx, yy, prob.data.numpy())\n",
+        "        plt.gca().set_aspect('equal', 'box')\n",
+        "        plt.show()\n",
+        "\n",
+        "# Plot loss\n",
+        "plt.figure(figsize=(10, 10))\n",
+        "plt.plot(loss_hist, label='loss')\n",
+        "plt.legend()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 754
+        },
+        "id": "KTeqlOJ-ojXG",
+        "outputId": "7644d64e-7f84-4d34-81be-d5d3732182a8"
+      },
+      "outputs": [],
+      "source": [
+        "# Plot learned distribution\n",
+        "nfm.eval()\n",
+        "log_prob = nfm.log_prob(zz).to('cpu').view(*xx.shape)\n",
+        "nfm.train()\n",
+        "prob = torch.exp(log_prob)\n",
+        "prob[torch.isnan(prob)] = 0\n",
+        "\n",
+        "plt.figure(figsize=(15, 15))\n",
+        "plt.pcolormesh(xx, yy, prob.data.numpy())\n",
+        "plt.gca().set_aspect('equal', 'box')\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "R8W1viPIovDu"
+      },
+      "outputs": [],
+      "source": [
+        "def aten_linalg_inv(g, arg):\n",
+        "    return g.op(\"com.microsoft::Inverse\", arg)\n",
+        "\n",
+        "# Register custom symbolic function\n",
+        "torch.onnx.register_custom_op_symbolic(\"aten::linalg_inv\", aten_linalg_inv, 17)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "tarbsJyKo2NU",
+        "outputId": "6546fd78-af31-44e5-e55b-7a5ed50635a5"
+      },
+      "outputs": [],
+      "source": [
+        "nfm.to(device)\n",
+        "\n",
+        "class FlowSampler(torch.nn.Module):\n",
+        "    def __init__(self, flow_model):\n",
+        "        super().__init__()\n",
+        "        self.flow_model = flow_model\n",
+        "\n",
+        "    def forward(self, z):\n",
+        "        x = self.flow_model.forward(z)\n",
+        "        return x\n",
+        "\n",
+        "sampler_model = FlowSampler(nfm)\n",
+        "sampler_model.eval()\n",
+        "\n",
+        "dummy_input = torch.randn(1000, latent_size, device=device)\n",
+        "onnx_model_path = \"onnx_sampler.onnx\"\n",
+        "\n",
+        "print(\"Exporting model to ONNX...\")\n",
+        "\n",
+        "torch.onnx.export(\n",
+        "    sampler_model,\n",
+        "    dummy_input,\n",
+        "    onnx_model_path,\n",
+        "    export_params=True,\n",
+        "    opset_version=17,\n",
+        "    input_names=['base_sample'],\n",
+        "    output_names=['target_sample'],\n",
+        "    dynamic_axes={\n",
+        "        'base_sample': {0: 'batch_size'},\n",
+        "        'target_sample': {0: 'batch_size'}\n",
+        "    },\n",
+        "    dynamo=False\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Q7Ttioaho_Zm",
+        "outputId": "ba8c17f4-f217-4955-b18c-fd4db8ba0bf4"
+      },
+      "outputs": [],
+      "source": [
+        "import onnxruntime as ort\n",
+        "\n",
+        "if device.type == 'cuda':\n",
+        "    providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']\n",
+        "else:\n",
+        "    providers = ['CPUExecutionProvider']\n",
+        "\n",
+        "\n",
+        "sess = ort.InferenceSession('onnx_sampler.onnx', providers=providers)\n",
+        "sample = np.random.randn(1000, 2).astype(np.float32)\n",
+        "output = sess.run(None, {'base_sample': sample})\n",
+        "output\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "RRpdbSRSpvzv"
+      },
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = "1.7.3"
+__version__ = "1.7.4"
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
This pull request introduces a new ONNX export example notebook and refactors key flow and spline utility functions to support ONNX export. The changes are grouped below:

**New Example and ONNX Export Support**
* Added `examples/onnx_export.ipynb`, a notebook demonstrating how to train a Neural Spline Flow model and export it to ONNX format. The notebook includes custom symbolic registration for ONNX export and validation using `onnxruntime`.

**Refactoring and Numerical Stability in Mixing Flows**
* Simplified the inverse operation in `Mixing` flow (`inverse_no_cache` in `normflows/flows/mixing.py`) by replacing triangular solve logic with a direct matrix inversion via `weight_inverse()`, making it compatible with ONNX and keeping the same outputs as before.
* Refactored `weight_inverse()` in `normflows/flows/mixing.py` to use `torch.inverse()` directly, removing the previous two-step triangular solve.

**Spline Utility Improvements**
* Refactored `unconstrained_rational_quadratic_spline` in `normflows/utils/splines.py` to clarify handling of derivatives and output initialization, and to use clamping for input bounds. The current implementation of `unconstrained_rational_quadratic_spline` uses boolean indexing (e.g., `inputs[mask]`) to separate values inside the tail bounds from those outside. While this works in eager mode, it breaks ONNX export and TorchScript. When exporting, PyTorch traces the graph with a specific batch of data. If boolean indexing is used, the resulting ONNX graph hardcodes the specific number of elements that fell inside the mask during the trace (e.g., if 900/1000 elements are inside, the graph creates a Reshape node for size 900). During inference, if a different number of elements fall inside the bounds, ONNX Runtime crashes with a shape mismatch error. This PR pre-clamp the inputs to `[-tail_bound, tail_bound]` before passing them to the spline function to prevent numerical instability or `NaNs` for out-of-bound values. I use `torch.where(mask, spline_output, identity_output)` to merge the results.
* Updated the output assignment in `unconstrained_rational_quadratic_spline` to use `torch.where`, simplifying the masking logic and ensuring correct handling of outputs and log determinants for inputs inside and outside the interval. These both changes are needed for edge cases to work with ONNX.

Let me know if something is unclear or need to be fixed.